### PR TITLE
NotSelfRefVecItem is impelemented

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "PinnedVec trait serves as a marker trait with common vector functionalities which additionally preserves the memory locations of vector elements; i.e., keeps them pinned."
@@ -8,7 +8,5 @@ license = "MIT"
 repository = "https://github.com/orxfun/orx-pinned-vec/"
 keywords = ["vec", "array", "vector", "pinned", "memory"]
 categories = ["data-structures"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,23 @@ for vector implementations which
 
 * preserves the memory locations of their elements; i.e., keeps them pinned.
 
-This feature eliminates a specific set of errors leading to undefined behavior (UB),
+The goal of the pinned vector implementations is to make it convenient, efficient and safe
+to implement complex data structures child structures of which often hold references
+to each other, such as trees or graphs.
+
+The following methods which would break this guarantee are `unsafe` for pinned vectors unlike
+the standard vector:
+
+* `insert`
+* `remove`
+* `pop`
+
+Since, pinned vectors will often contain items holding references to each other,
+default `clone` implementation is also `unsafe`.
+
+# Safety
+
+The abovementioned feature eliminates a specific set of errors leading to undefined behavior (UB),
 and hence, allows to work with a more flexible borrow checker.
 Consider for instance the following code block which does not compile.
 
@@ -30,8 +46,8 @@ memory locations do not happen; and hence, eliminating the cause of the UB obser
 See, [`FixedVec`](https://crates.io/crates/orx-fixed-vec) and [`SplitVec`](https://crates.io/crates/orx-split-vec)
 for two basic pinned-vector implementations.
 
-Further, see [`ImpVec`](https://crates.io/crates/orx-imp-vec) crate which allows converting
-any `PinnedVec` implementation into an imp-vec.
+Further, see [`ImpVec`](https://crates.io/crates/orx-imp-vec) which allows converting any `PinnedVec`
+implementation into an imp-vec.
 An imp-vec stands for immutable-push-vector, literally allowing to push to the vector with an
 immutable reference.
 This turns out to be a very useful opeartion, allowing to conveniently implement tricky data structures.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,15 +3,29 @@
 //!
 //! * preserves the memory locations of their elements; i.e., keeps them pinned.
 //!
-//! This feature eliminates a specific set of errors leading to undefined behavior (UB),
-//! and hence, allows to work with a more flexible borrow checker.
+//! The goal of the pinned vector implementations is to make it convenient, efficient and safe
+//! to implement complex data structures child structures of which often hold references
+//! to each other, such as trees or graphs.
 //!
+//! The following methods which would break this guarantee are `unsafe` for pinned vectors unlike
+//! the standard vector:
+//!
+//! * `insert`
+//! * `remove`
+//! * `pop`
+//!
+//! Since, pinned vectors will often contain items holding references to each other,
+//! default `clone` implementation is also `unsafe`.
+//!
+//! # Safety
+//!
+//! The abovementioned feature eliminates a specific set of errors leading to undefined behavior (UB),
+//! and hence, allows to work with a more flexible borrow checker.
 //! Consider for instance the following code block which does not compile.
 //!
-//! ```
+//! ```rust
 //! let mut vec = Vec::with_capacity(2);
 //! vec.extend_from_slice(&[0, 1]);
-//!
 //! let ref0 = &vec[0];
 //! vec.push(2);
 //! // let value0 = *ref0; // does not compile!
@@ -30,8 +44,8 @@
 //! See, [`FixedVec`](https://crates.io/crates/orx-fixed-vec) and [`SplitVec`](https://crates.io/crates/orx-split-vec)
 //! for two basic pinned-vector implementations.
 //!
-//! Further, see [`ImpVec`](https://crates.io/crates/orx-imp-vec) crate which allows converting
-//! any `PinnedVec` implementation into an imp-vec.
+//! Further, see [`ImpVec`](https://crates.io/crates/orx-imp-vec) which allows converting any `PinnedVec`
+//! implementation into an imp-vec.
 //! An imp-vec stands for immutable-push-vector, literally allowing to push to the vector with an
 //! immutable reference.
 //! This turns out to be a very useful opeartion, allowing to conveniently implement tricky data structures.
@@ -49,4 +63,9 @@
 )]
 
 mod pinned_vec;
+mod pinned_vec_simple;
+mod self_ref;
+
 pub use pinned_vec::PinnedVec;
+pub use pinned_vec_simple::PinnedVecSimple;
+pub use self_ref::NotSelfRefVecItem;

--- a/src/pinned_vec_simple.rs
+++ b/src/pinned_vec_simple.rs
@@ -1,0 +1,103 @@
+use crate::{NotSelfRefVecItem, PinnedVec};
+
+/// `PinnedVecSimple` is a `PinnedVec` where the elements satisfy the trait bound
+/// `T: NotSelfRefVecItem.
+///
+/// In other words, elements of the vector does not hold references to other
+/// elements of the same vector.
+/// Note that this is satisfied for all `std::vec::Vec`s.
+///
+/// On the other hand, `PinnedVec` is designed to conveniently build more complex
+/// data structures while holding children of these data structures in a vec-like
+/// layout for better cache locality and to reduce heap allocations.
+///
+/// These structures often contain child structures referencing each other;
+/// such as the `parent` or `children` relations of a tree.
+/// `PinnedVec` aims at guaranteeing that these internal references are kept valid.
+/// This makes methods `insert`, `remove` and `pop` unsafe.
+///
+/// Since the aforementioned safety concern is absent when elements do not hold such internal references;
+/// i.e., when `T: NotSelfRefVecItem`,
+/// such vectors automatically implement `PinnedVecSimple` which enables safe calls
+/// to these methods.
+///
+/// # Safety
+///
+/// Picking the more conservative and safer approach;
+/// the default versions of methods `insert`, `remove` and `pop` are unsafe.
+///
+/// In order to be able to make safe calls to these methods,
+/// once must explicitly implement `NotSelfRefVecItem` for the element type.
+/// This is a marker trait, and hence, easy to implement.
+///
+/// For convenience,
+/// this crate already contains implementations for the primitive structs
+/// such as numbers, string or bool.
+pub trait PinnedVecSimple<T>: PinnedVec<T>
+where
+    T: NotSelfRefVecItem,
+{
+    /// Inserts an element at position index within the vector, shifting all elements after it to the right.
+    ///
+    /// # Panics
+    /// Panics if `index >= len`.
+    ///
+    /// # Safety
+    ///
+    /// `insert` operation for a `PinnedVecSimple` where the elements are `T: NotSelfRefVecItem` is **safe**;
+    /// in this case, pinned vector shares the same safety requirements as `std::vec::Vec` which is readily
+    /// provided by the borrow checker.
+    fn insert(&mut self, index: usize, element: T);
+    /// Removes and returns the element at position index within the vector, shifting all elements after it to the left.
+    ///
+    /// # Panics
+    ///
+    /// Panics if index is out of bounds.
+    ///
+    /// # Safety
+    ///
+    /// `remove` operation for a `PinnedVecSimple` where the elements are `T: NotSelfRefVecItem` is **safe**;
+    /// in this case, pinned vector shares the same safety requirements as `std::vec::Vec` which is readily
+    /// provided by the borrow checker.
+    fn remove(&mut self, index: usize) -> T;
+    /// Removes the last element from a vector and returns it, or None if it is empty.
+    ///
+    /// # Safety
+    ///
+    /// `pop` operation for a `PinnedVecSimple` where the elements are `T: NotSelfRefVecItem` is **safe**;
+    /// in this case, pinned vector shares the same safety requirements as `std::vec::Vec` which is readily
+    /// provided by the borrow checker.
+    fn pop(&mut self) -> Option<T>;
+    /// Creates and returns a clone of the vector.
+    ///
+    /// # Safety
+    ///
+    /// `clone` operation for a `PinnedVecSimple` where the elements are `T: NotSelfRefVecItem` is **safe**;
+    /// in this case, pinned vector shares the same safety requirements as `std::vec::Vec` which is readily
+    /// provided by the borrow checker.
+    fn clone(&self) -> Self
+    where
+        T: Clone;
+}
+
+impl<T, V> PinnedVecSimple<T> for V
+where
+    T: NotSelfRefVecItem,
+    V: PinnedVec<T>,
+{
+    fn insert(&mut self, index: usize, element: T) {
+        unsafe { <Self as PinnedVec<T>>::insert(self, index, element) }
+    }
+    fn remove(&mut self, index: usize) -> T {
+        unsafe { <Self as PinnedVec<T>>::remove(self, index) }
+    }
+    fn pop(&mut self) -> Option<T> {
+        unsafe { <Self as PinnedVec<T>>::pop(self) }
+    }
+    fn clone(&self) -> Self
+    where
+        T: Clone,
+    {
+        unsafe { <Self as PinnedVec<T>>::clone(self) }
+    }
+}

--- a/src/self_ref.rs
+++ b/src/self_ref.rs
@@ -1,0 +1,131 @@
+use std::num::*;
+
+/// Marker trait for types to be contained in a `PinnedVec` which do not hold a field
+/// which is a reference to a another element of the same vector.
+///
+/// Note that any type which does not implement `NotSelfRefVecItem` marker trait
+/// is accepted to be a self-referencing-vector-item due to the following:
+///
+/// * `PinnedVec` is particularly useful for defining complex data structures
+/// which elements of which often references each other;
+/// in other words, most of the time `PinnedVec<T>` will be used.
+/// * To be able to use `PinnedVecSimple: PinnedVec` for safe calls to `insert`, `remove`, `pop` and `clone`,
+/// one must explicitly implement `NotSelfRefVecItem` for the elements
+/// explicitly stating the safety of the usage.
+/// * Finally, this trait is already implemented for most of the common
+/// primitive types.
+///
+/// It is more brief to describe what a self-referencing-vector-item is
+/// rather than describing `NotSelfRefVecItem`.
+/// Therefore, such an example struct is demonstrated in the following section.
+///
+/// # Example
+///
+/// Consider the following type which is common to tree structures:
+///
+/// ```rust
+/// struct TreeNode<'a, T> {
+///     value: T,
+///     parent: Option<&'a TreeNode<'a, T>>,
+/// }
+/// ```
+///
+/// Further assume that we want to keep nodes of all trees in the same vector.
+/// Compared to alternatives, this is helpful at least for the following reasons:
+///
+/// * keeping all nodes together helps in achieving better cache locality,
+/// * the references defining the tree structure are thin rather than wide pointers,
+/// * requires less heap allocations: only the vector is allocated together with all its elements,
+/// as opposed to allocating each node separately in an arbitrary memory location.
+///
+/// On the other hand, such data structures require more care about safety and correctness.
+/// Since each vector element can hold a reference to another vector element,
+/// `mut` methods need to be investigated carefully.
+///
+/// Consider for instance a vector of two nodes, say `a` and `b`,
+/// each has the other as the `parent`; i.e., defining a cyclic relationship `a <--> b`.
+/// Assume that we `insert` another node at the beginning of this vector, say `x`,
+/// resulting in the vector `[ x, a, b ]`.
+/// Now `a`'s parent appears to be itself (position 1);
+/// and `b`'s parent appears to be `x` (position 0).
+/// This is not an undefined behavior (UB) in the classical sense; however,
+/// it is certainly an UB in terms of the tree that the vector is supposed to represent.
+///
+/// Alternatively, if we call `remove(1)` on this vector, we end up with the vector `[ x ]`.
+/// Now `x` is pointing to a memory location that does not belong to this vector;
+/// we end up with a classical UB this time.
+///
+/// Therefore, all mut methods which change positions of already existing elements
+/// (including removal of elements from the vector)
+/// are considered to be **`unsafe`** when `T` is not a `NotSelfRefVecItem`.
+///
+/// # Significance
+///
+/// ## Unsafe methods when `T` is not a `NotSelfRefVecItem`
+///
+/// Whether the element type of a `PinnedVec` is `NotSelfRefVecItem` or not
+/// has an impact on the mutable operations which change positions of already pushed elements.
+///
+/// The following is the complete list of these methods:
+///
+/// * `insert`
+/// * `remove`
+/// * `pop`
+/// * `clone`
+///
+/// These methods can be called safely when `T: NotSelfRefVecItem`;
+/// only within an `unsafe` block otherwise.
+///
+/// ## Safe methods regardless of `T` is a `NotSelfRefVecItem` or not
+///
+/// On the other hand, `mut` methods such as `push` or `extend_from_slice` are **safe**
+/// since a `PinnedVec` keeps positions of already pushed elements intact while growing.
+/// Therefore, references to already pushed elements will remain valid.
+///
+/// Although it leads to removal of elements,
+/// `clear` is also **safe** for all element types.
+/// This is because all elements are dropped together with their possible references.
+///
+/// # Trait Implementations
+///
+/// To pick the conservative implementation,
+/// one must explicitly implement this marker trait `NotSelfReferencingVecItem`
+/// on the type to be contained in a `PinnedVec`.
+///
+/// On the other hand, they are already implemented for primitives for convenience
+/// such as numeric types, strings, etc.
+pub trait NotSelfRefVecItem {}
+
+// auto impl
+impl<T> NotSelfRefVecItem for &T where T: NotSelfRefVecItem {}
+impl<T> NotSelfRefVecItem for Option<T> where T: NotSelfRefVecItem {}
+
+impl NotSelfRefVecItem for bool {}
+impl NotSelfRefVecItem for char {}
+impl NotSelfRefVecItem for f32 {}
+impl NotSelfRefVecItem for f64 {}
+impl NotSelfRefVecItem for i128 {}
+impl NotSelfRefVecItem for i16 {}
+impl NotSelfRefVecItem for i32 {}
+impl NotSelfRefVecItem for i64 {}
+impl NotSelfRefVecItem for i8 {}
+impl NotSelfRefVecItem for isize {}
+impl NotSelfRefVecItem for NonZeroI128 {}
+impl NotSelfRefVecItem for NonZeroI16 {}
+impl NotSelfRefVecItem for NonZeroI32 {}
+impl NotSelfRefVecItem for NonZeroI64 {}
+impl NotSelfRefVecItem for NonZeroI8 {}
+impl NotSelfRefVecItem for NonZeroIsize {}
+impl NotSelfRefVecItem for NonZeroU128 {}
+impl NotSelfRefVecItem for NonZeroU16 {}
+impl NotSelfRefVecItem for NonZeroU32 {}
+impl NotSelfRefVecItem for NonZeroU64 {}
+impl NotSelfRefVecItem for NonZeroU8 {}
+impl NotSelfRefVecItem for NonZeroUsize {}
+impl NotSelfRefVecItem for str {}
+impl NotSelfRefVecItem for String {}
+impl NotSelfRefVecItem for u128 {}
+impl NotSelfRefVecItem for u16 {}
+impl NotSelfRefVecItem for u32 {}
+impl NotSelfRefVecItem for u64 {}
+impl NotSelfRefVecItem for u8 {}


### PR DESCRIPTION
Element moving methods are marked as `unsafe` for `PinnedVec`.

`PinnedVecSimple` is defined and automatically implemented for vectors implementing `PinnedVec` for which the vector element implements `NotSelfRefVecItem`.

`PinnedVecSimple` allows safe calls to element moving mut methods.