### PR TITLE
unsafe_ prefix is added for unsafe methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "PinnedVec trait serves as a marker trait with common vector functionalities which additionally preserves the memory locations of vector elements; i.e., keeps them pinned."

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -97,7 +97,7 @@ pub trait PinnedVec<T> {
     ///
     /// On the other hand, any vector implementing `PinnedVec<T>` where `T: NotSelfRefVecItem`
     /// implements `PinnedVecSimple<T>` which implements the safe version of this method.
-    unsafe fn insert(&mut self, index: usize, element: T);
+    unsafe fn unsafe_insert(&mut self, index: usize, element: T);
     /// Removes and returns the element at position index within the vector, shifting all elements after it to the left.
     ///
     /// # Panics
@@ -118,7 +118,7 @@ pub trait PinnedVec<T> {
     ///
     /// On the other hand, any vector implementing `PinnedVec<T>` where `T: NotSelfRefVecItem`
     /// implements `PinnedVecSimple<T>` which implements the safe version of this method.
-    unsafe fn remove(&mut self, index: usize) -> T;
+    unsafe fn unsafe_remove(&mut self, index: usize) -> T;
     /// Removes the last element from a vector and returns it, or None if it is empty.
     ///
     /// # Safety
@@ -132,7 +132,7 @@ pub trait PinnedVec<T> {
     ///
     /// On the other hand, any vector implementing `PinnedVec<T>` where `T: NotSelfRefVecItem`
     /// implements `PinnedVecSimple<T>` which implements the safe version of this method.
-    unsafe fn pop(&mut self) -> Option<T>;
+    unsafe fn unsafe_pop(&mut self) -> Option<T>;
     /// Creates and returns a clone of the vector.
     ///
     /// # Safety
@@ -149,7 +149,7 @@ pub trait PinnedVec<T> {
     /// * In this case, elements of `cl` are pointing to elements of `vec`.
     ///     * This is not correct, as these references are to be kept internal to the vector.
     ///     * Furthermore, if `vec` is dropped, `cl` elements will contain invalid references leading to UB.
-    unsafe fn clone(&self) -> Self
+    unsafe fn unsafe_clone(&self) -> Self
     where
         T: Clone;
 

--- a/src/pinned_vec_simple.rs
+++ b/src/pinned_vec_simple.rs
@@ -85,19 +85,23 @@ where
     T: NotSelfRefVecItem,
     V: PinnedVec<T>,
 {
+    #[inline(always)]
     fn insert(&mut self, index: usize, element: T) {
-        unsafe { <Self as PinnedVec<T>>::insert(self, index, element) }
+        unsafe { self.unsafe_insert(index, element) }
     }
+    #[inline(always)]
     fn remove(&mut self, index: usize) -> T {
-        unsafe { <Self as PinnedVec<T>>::remove(self, index) }
+        unsafe { self.unsafe_remove(index) }
     }
+    #[inline(always)]
     fn pop(&mut self) -> Option<T> {
-        unsafe { <Self as PinnedVec<T>>::pop(self) }
+        unsafe { self.unsafe_pop() }
     }
+    #[inline(always)]
     fn clone(&self) -> Self
     where
         T: Clone,
     {
-        unsafe { <Self as PinnedVec<T>>::clone(self) }
+        unsafe { self.unsafe_clone() }
     }
 }


### PR DESCRIPTION
This is required for convenience; otherwise, the implementer will receive `multiple methods found` error.