### PR TITLE
SelfRefVecItem trait is defined

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "PinnedVec trait serves as a marker trait with common vector functionalities which additionally preserves the memory locations of vector elements; i.e., keeps them pinned."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,10 +67,12 @@
     clippy::todo
 )]
 
+mod not_self_ref;
 mod pinned_vec;
 mod pinned_vec_simple;
 mod self_ref;
 
+pub use not_self_ref::NotSelfRefVecItem;
 pub use pinned_vec::PinnedVec;
 pub use pinned_vec_simple::PinnedVecSimple;
-pub use self_ref::NotSelfRefVecItem;
+pub use self_ref::SelfRefVecItem;

--- a/src/not_self_ref.rs
+++ b/src/not_self_ref.rs
@@ -1,0 +1,135 @@
+use std::num::*;
+
+/// Marker trait for types to be contained in a `PinnedVec` which do not hold a field
+/// which is a reference to a another element of the same vector.
+///
+/// Note that any type which does not implement `NotSelfRefVecItem` marker trait
+/// is accepted to be a self-referencing-vector-item due to the following:
+///
+/// * `PinnedVec` is particularly useful for defining complex data structures
+/// which elements of which often references each other;
+/// in other words, most of the time `PinnedVec<T>` will be used.
+/// * To be able to use `PinnedVecSimple: PinnedVec` for safe calls to `insert`, `remove`, `pop` and `clone`,
+/// one must explicitly implement `NotSelfRefVecItem` for the elements
+/// explicitly stating the safety of the usage.
+/// * Finally, this trait is already implemented for most of the common
+/// primitive types.
+///
+/// It is more brief to describe what a `SelfRefVecItem` is
+/// rather than describing `NotSelfRefVecItem`.
+/// Such data types are particularly useful for data types defining
+/// relations about its children such as trees or graphs.
+/// An example struct is demonstrated in the following section.
+///
+/// # Example
+///
+/// Consider the following type which is common to tree structures:
+///
+/// ```rust
+/// struct TreeNode<'a, T> {
+///     value: T,
+///     parent: Option<&'a TreeNode<'a, T>>,
+/// }
+/// ```
+///
+/// Further assume that we want to keep nodes of all trees in the same vector.
+/// Compared to alternatives, this is helpful at least for the following reasons:
+///
+/// * keeping all nodes together helps in achieving better cache locality,
+/// * the references defining the tree structure are thin rather than wide pointers,
+/// * requires less heap allocations: only the vector is allocated together with all its elements,
+/// as opposed to allocating each node separately in an arbitrary memory location.
+///
+/// # Safety
+/// On the other hand, such data structures require more care about safety and correctness.
+/// Since each vector element can hold a reference to another vector element,
+/// `mut` methods need to be investigated carefully.
+///
+/// Consider for instance a vector of two nodes, say `a` and `b`,
+/// each has the other as the `parent`; i.e., defining a cyclic relationship `a <--> b`.
+/// Assume that we `insert` another node at the beginning of this vector, say `x`,
+/// resulting in the vector `[ x, a, b ]`.
+/// Now `a`'s parent appears to be itself (position 1);
+/// and `b`'s parent appears to be `x` (position 0).
+/// This is not an undefined behavior (UB) in the classical sense; however,
+/// it is certainly an UB in terms of the tree that the vector is supposed to represent.
+///
+/// Alternatively, if we call `remove(1)` on this vector, we end up with the vector `[ x ]`.
+/// Now `x` is pointing to a memory location that does not belong to this vector;
+/// we end up with a classical UB this time.
+///
+/// Therefore, all mut methods which change positions of already existing elements
+/// (including removal of elements from the vector)
+/// are considered to be **`unsafe`** when `T` is not a `NotSelfRefVecItem`.
+///
+/// # Significance
+///
+/// ## Unsafe methods when `T` is not a `NotSelfRefVecItem`
+///
+/// Whether the element type of a `PinnedVec` is `NotSelfRefVecItem` or not
+/// has an impact on the mutable operations which change positions of already pushed elements.
+///
+/// The following is the complete list of these methods:
+///
+/// * `insert`
+/// * `remove`
+/// * `pop`
+/// * `clone`
+///
+/// These methods can be called safely when `T: NotSelfRefVecItem`;
+/// only within an `unsafe` block otherwise.
+///
+/// ## Safe methods regardless of `T` is a `NotSelfRefVecItem` or not
+///
+/// On the other hand, `mut` methods such as `push` or `extend_from_slice` are **safe**
+/// since a `PinnedVec` keeps positions of already pushed elements intact while growing.
+/// Therefore, references to already pushed elements will remain valid.
+///
+/// Although it leads to removal of elements,
+/// `clear` is also **safe** for all element types.
+/// This is because all elements are dropped together with their possible references.
+///
+/// # Trait Implementations
+///
+/// To pick the conservative implementation,
+/// one must explicitly implement this marker trait `NotSelfReferencingVecItem`
+/// on the type to be contained in a `PinnedVec`.
+///
+/// On the other hand, they are already implemented for primitives for convenience
+/// such as numeric types, strings, etc.
+pub trait NotSelfRefVecItem {}
+
+// auto impl
+impl<T> NotSelfRefVecItem for &T where T: NotSelfRefVecItem {}
+impl<T> NotSelfRefVecItem for Option<T> where T: NotSelfRefVecItem {}
+
+impl NotSelfRefVecItem for bool {}
+impl NotSelfRefVecItem for char {}
+impl NotSelfRefVecItem for f32 {}
+impl NotSelfRefVecItem for f64 {}
+impl NotSelfRefVecItem for i128 {}
+impl NotSelfRefVecItem for i16 {}
+impl NotSelfRefVecItem for i32 {}
+impl NotSelfRefVecItem for i64 {}
+impl NotSelfRefVecItem for i8 {}
+impl NotSelfRefVecItem for isize {}
+impl NotSelfRefVecItem for NonZeroI128 {}
+impl NotSelfRefVecItem for NonZeroI16 {}
+impl NotSelfRefVecItem for NonZeroI32 {}
+impl NotSelfRefVecItem for NonZeroI64 {}
+impl NotSelfRefVecItem for NonZeroI8 {}
+impl NotSelfRefVecItem for NonZeroIsize {}
+impl NotSelfRefVecItem for NonZeroU128 {}
+impl NotSelfRefVecItem for NonZeroU16 {}
+impl NotSelfRefVecItem for NonZeroU32 {}
+impl NotSelfRefVecItem for NonZeroU64 {}
+impl NotSelfRefVecItem for NonZeroU8 {}
+impl NotSelfRefVecItem for NonZeroUsize {}
+impl NotSelfRefVecItem for str {}
+impl NotSelfRefVecItem for String {}
+impl NotSelfRefVecItem for u128 {}
+impl NotSelfRefVecItem for u16 {}
+impl NotSelfRefVecItem for u32 {}
+impl NotSelfRefVecItem for u64 {}
+impl NotSelfRefVecItem for u8 {}
+impl NotSelfRefVecItem for usize {}

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -133,6 +133,47 @@ pub trait PinnedVec<T> {
     /// On the other hand, any vector implementing `PinnedVec<T>` where `T: NotSelfRefVecItem`
     /// implements `PinnedVecSimple<T>` which implements the safe version of this method.
     unsafe fn unsafe_pop(&mut self) -> Option<T>;
+    /// Swaps two elements in the slice.
+    ///
+    /// If `a` equals to `b`, it's guaranteed that elements won't change value.
+    ///
+    /// # Arguments
+    ///
+    /// * a - The index of the first element
+    /// * b - The index of the second element
+    ///
+    /// # Safety
+    ///
+    /// This operation is **unsafe** when `T` is not `NotSelfRefVecItem`.
+    /// To pick the conservative approach, every T which does not implement `NotSelfRefVecItem`
+    /// is assumed to be a vector item referencing other vector items.
+    ///
+    /// `swap` is unsafe since it is possible that other elements are referencing one of the
+    /// elements to be swapped.
+    /// The swap operation does not lead to an undefined behavior in the classical sense;
+    /// however, would invalidate the inter-elements-references.
+    ///
+    /// On the other hand, any vector implementing `PinnedVec<T>` where `T: NotSelfRefVecItem`
+    /// implements `PinnedVecSimple<T>` which implements the safe version of this method.
+    unsafe fn unsafe_swap(&mut self, a: usize, b: usize);
+    /// Shortens the vector, keeping the first `len` elements and dropping
+    /// the rest.
+    ///
+    /// If `len` is greater than the vector's current length, this has no
+    /// effect.
+    ///
+    /// # Safety
+    ///
+    /// This operation is **unsafe** when `T` is not `NotSelfRefVecItem`.
+    /// To pick the conservative approach, every T which does not implement `NotSelfRefVecItem`
+    /// is assumed to be a vector item referencing other vector items.
+    ///
+    /// `truncate` is unsafe since it is possible that remaining elements are referencing
+    /// to elements which are dropped by the truncate method.
+    ///
+    /// On the other hand, any vector implementing `PinnedVec<T>` where `T: NotSelfRefVecItem`
+    /// implements `PinnedVecSimple<T>` which implements the safe version of this method.
+    unsafe fn unsafe_truncate(&mut self, len: usize);
     /// Creates and returns a clone of the vector.
     ///
     /// # Safety

--- a/src/pinned_vec_simple.rs
+++ b/src/pinned_vec_simple.rs
@@ -68,6 +68,27 @@ where
     /// in this case, pinned vector shares the same safety requirements as `std::vec::Vec` which is readily
     /// provided by the borrow checker.
     fn pop(&mut self) -> Option<T>;
+    /// Swaps two elements in the slice.
+    ///
+    /// If `a` equals to `b`, it's guaranteed that elements won't change value.
+    ///
+    /// # Arguments
+    ///
+    /// * a - The index of the first element
+    /// * b - The index of the second element
+    ///
+    /// # Safety
+    ///
+    /// `swap` operation for a `PinnedVecSimple` where the elements are `T: NotSelfRefVecItem` is **safe**;
+    /// in this case, pinned vector shares the same safety requirements as `std::vec::Vec` which is readily
+    /// provided by the borrow checker.
+    fn swap(&mut self, a: usize, b: usize);
+    /// Shortens the vector, keeping the first `len` elements and dropping
+    /// the rest.
+    ///
+    /// If `len` is greater than the vector's current length, this has no
+    /// effect.
+    fn truncate(&mut self, len: usize);
     /// Creates and returns a clone of the vector.
     ///
     /// # Safety
@@ -97,6 +118,15 @@ where
     fn pop(&mut self) -> Option<T> {
         unsafe { self.unsafe_pop() }
     }
+    #[inline(always)]
+    fn swap(&mut self, a: usize, b: usize) {
+        unsafe { self.unsafe_swap(a, b) }
+    }
+    #[inline(always)]
+    fn truncate(&mut self, len: usize) {
+        unsafe { self.unsafe_truncate(len) }
+    }
+
     #[inline(always)]
     fn clone(&self) -> Self
     where


### PR DESCRIPTION
* swap and truncate methods are added to the trait.
* SelfRefVecItem trait is defined for prev-next type of relationships, to be extended later for different kinds of relations.