### PR TITLE
contains_reference method is added

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -51,13 +51,27 @@ pub trait PinnedVec<T> {
     /// Note that `T: Eq` is not required; reference equality is used.
     ///
     /// The complexity of this method depends on the particular `PinnedVec` implementation.
-    /// However, making use of referential equality, it ispossible to perform much better than *O(n)*,
+    /// However, making use of referential equality, it possible to perform much better than *O(n)*,
     /// where n is the vector length.
     ///
     /// For the two example implementations, complexity of this method:
     /// * *O(1)* for [FixedVec](https://crates.io/crates/orx-fixed-vec);
     /// * *O(f)* for [SplitVec](https://crates.io/crates/orx-split-vec) where f << n is the number of fragments.
-    fn index_of(&self, data: &T) -> Option<usize>;
+    fn index_of(&self, element: &T) -> Option<usize>;
+
+    /// Returns whether or not of the `element` with the given reference belongs to this vector.
+    /// In other words, returns whether or not the reference to the `element` is valid.
+    ///
+    /// Note that `T: Eq` is not required; memory address is used.
+    ///
+    /// The complexity of this method depends on the particular `PinnedVec` implementation.
+    /// However, making use of pinned element guarantees, it possible to perform much better than *O(n)*,
+    /// where n is the vector length.
+    ///
+    /// For the two example implementations, complexity of this method:
+    /// * *O(1)* for [FixedVec](https://crates.io/crates/orx-fixed-vec);
+    /// * *O(f)* for [SplitVec](https://crates.io/crates/orx-split-vec) where f << n is the number of fragments.
+    fn contains_reference(&self, element: &T) -> bool;
 
     // vec
     /// Clears the vector, removing all values.

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -34,6 +34,10 @@ mod tests {
             crate::utils::slice::index_of(&self.0, data)
         }
 
+        fn contains_reference(&self, element: &T) -> bool {
+            self.index_of(element).is_some()
+        }
+
         fn clear(&mut self) {
             self.0.clear();
         }

--- a/src/pinned_vec_tests/testvec.rs
+++ b/src/pinned_vec_tests/testvec.rs
@@ -24,6 +24,10 @@ impl<T> PinnedVec<T> for TestVec<T> {
         crate::utils::slice::index_of(&self.0, data)
     }
 
+    fn contains_reference(&self, element: &T) -> bool {
+        self.index_of(element).is_some()
+    }
+
     fn clear(&mut self) {
         self.0.clear();
     }

--- a/src/utils/slice.rs
+++ b/src/utils/slice.rs
@@ -1,4 +1,4 @@
-/// Returns the index of the `element` with the given reference.
+/// Returns the index of the `element` with the given reference inside the `slice`.
 /// This method has *O(1)* time complexity.
 ///
 /// # Safety
@@ -28,6 +28,34 @@ pub fn index_of<T>(slice: &[T], element: &T) -> Option<usize> {
     }
 }
 
+/// Returns whether or not `element` with the given reference belongs to the given `slice`.
+/// This method has *O(1)* time complexity.
+///
+/// # Safety
+///
+/// The underlying memory of the slice `&[T]` stays pinned as long as
+/// the reference is in scope; i.e., is not carried to different memory locations.
+///
+/// Therefore, it is possible and safe to compare an element's reference
+/// to find its position in the vector.
+///
+/// Out of bounds checks are in place.
+pub fn contains_reference<T>(slice: &[T], element: &T) -> bool {
+    if slice.is_empty() {
+        false
+    } else {
+        let ptr_element = element as *const T as usize;
+        let ptr = slice.as_ptr();
+        let ptr_beg = ptr as usize;
+        if ptr_element < ptr_beg {
+            false
+        } else {
+            let ptr_end = (unsafe { ptr.add(slice.len() - 1) }) as usize;
+            ptr_element <= ptr_end
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     pub use super::*;
@@ -46,12 +74,38 @@ mod tests {
 
     #[test]
     fn index_of_some() {
-        let array = [0, 1, 2, 3];
+        let n = 1234;
+        let array: Vec<_> = (0..n).collect();
 
         for i in 0..array.len() {
             let element = &array[i];
             let index = index_of(&array, element);
             assert_eq!(Some(i), index);
+        }
+    }
+
+    #[test]
+    fn contains_reference_wrong() {
+        let n = 1234;
+        let array1: Vec<_> = (0..n).collect();
+        let array2: Vec<_> = (0..(n - 1)).collect();
+
+        for element in array1.iter() {
+            assert!(!contains_reference(&array2, element));
+        }
+
+        for element in array2.iter() {
+            assert!(!contains_reference(&array1, element));
+        }
+    }
+
+    #[test]
+    fn contains_reference_correct() {
+        let n = 1111;
+        let array: Vec<_> = (0..n).collect();
+
+        for element in array.iter() {
+            assert!(contains_reference(&array, element));
         }
     }
 }


### PR DESCRIPTION
* `PinnedVec::contains_reference` method is added to the trait definition. This method is expected to return true whenever `index_of` returns `Some`. However, since the `contains_reference` requires less work and can return faster, a default implementation is not provided.
* Helper method `slice::contains_reference` is implemented and made available to be used by the trait implementers.