### PR TITLE
get_ptr_mut is defined

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -189,6 +189,16 @@ pub trait PinnedVec<T> {
     /// Returns a reversed back-to-front iterator mutable references to elements of the vector.
     fn iter_mut_rev(&mut self) -> Self::IterMutRev<'_>;
 
+    /// Returns a mutable reference to the `index`-th element of the vector.
+    ///
+    /// Returns `None` if `index`-th position does not belong to the vector; i.e., if `index` is out of `capacity`.
+    ///
+    /// # Safety
+    ///
+    /// This method allows to write to a memory which is greater than the vector's length.
+    /// On the other hand, it will never return a pointer to a memory location that the vector does not own.
+    unsafe fn get_ptr_mut(&mut self, index: usize) -> Option<*mut T>;
+
     /// Forces the length of the vector to `new_len`.
     ///
     /// This is a low-level operation that maintains none of the normal invariants of the type.

--- a/src/pinned_vec_tests/mod.rs
+++ b/src/pinned_vec_tests/mod.rs
@@ -8,3 +8,4 @@ pub mod test_all;
 #[cfg(test)]
 pub(crate) mod testvec;
 mod truncate;
+mod unsafe_writer;

--- a/src/pinned_vec_tests/refmap.rs
+++ b/src/pinned_vec_tests/refmap.rs
@@ -34,7 +34,6 @@ impl RefMap {
         if max_len > 0 {
             for i in 0..max_num_indices {
                 let idx = random_index(i, max_len);
-                dbg!(idx);
                 map.entry(idx).or_insert(None);
             }
         }

--- a/src/pinned_vec_tests/testvec.rs
+++ b/src/pinned_vec_tests/testvec.rs
@@ -122,6 +122,14 @@ impl<T> PinnedVec<T> for TestVec<T> {
         self.0.iter_mut().rev()
     }
 
+    unsafe fn get_ptr_mut(&mut self, index: usize) -> Option<*mut T> {
+        if index < self.0.capacity() {
+            Some(self.0.as_mut_ptr().add(index))
+        } else {
+            None
+        }
+    }
+
     unsafe fn set_len(&mut self, new_len: usize) {
         self.0.set_len(new_len)
     }

--- a/src/pinned_vec_tests/unsafe_writer.rs
+++ b/src/pinned_vec_tests/unsafe_writer.rs
@@ -1,0 +1,39 @@
+use super::refmap::RefMap;
+use crate::PinnedVec;
+
+pub fn unsafe_writer<P: PinnedVec<usize>>(pinned_vec: P, max_allowed_test_len: usize) -> P {
+    let mut vec = pinned_vec;
+    vec.clear();
+
+    let mut refmap = RefMap::new(200, max_allowed_test_len);
+
+    let len1 = max_allowed_test_len / 2;
+
+    for i in 0..len1 {
+        vec.push(i);
+        refmap.set_reference(&vec, i);
+        refmap.validate_references(&vec);
+    }
+
+    assert_eq!(vec.len(), len1);
+
+    for i in len1..max_allowed_test_len {
+        if let Some(ptr) = unsafe { vec.get_ptr_mut(i) } {
+            unsafe { *ptr = i };
+
+            unsafe { vec.set_len(i + 1) };
+            assert_eq!(vec.len(), i + 1);
+
+            assert_eq!(vec.get(i), Some(&i));
+
+            refmap.set_reference(&vec, i);
+            refmap.validate_references(&vec);
+        }
+    }
+
+    for i in vec.capacity()..(vec.capacity() + 100) {
+        assert!(unsafe { vec.get_ptr_mut(i) }.is_none());
+    }
+
+    vec
+}


### PR DESCRIPTION
* `unsafe get_ptr_mut` function is defined.
* tests are extended to include `get_ptr_mut`.