### PR TITLE
PinnedVec is extended by `try_grow`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,8 @@
+/// Error occurred during an attempt to increase capacity of the pinned vector.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PinnedVecGrowthError {
+    /// An error stating that the vector is only allowed to grow if its entire current capacity is used.
+    CanOnlyGrowWhenVecIsAtCapacity,
+    /// An error which is observed when a pinned vector attempted to increase its capacity while keeping its already added elements pinned in their locations.
+    FailedToGrowWhileKeepingElementsPinned,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,10 +64,12 @@
     clippy::todo
 )]
 
+mod errors;
 mod pinned_vec;
 mod pinned_vec_tests;
 /// Utility functions to make PinnedVec implementations more convenient.
 pub mod utils;
 
+pub use errors::PinnedVecGrowthError;
 pub use pinned_vec::PinnedVec;
 pub use pinned_vec_tests::test_all::test_pinned_vec;

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -1,3 +1,5 @@
+use crate::errors::PinnedVecGrowthError;
+
 /// Trait for vector representations differing from `std::vec::Vec` by the following:
 ///
 /// => memory location of an element already pushed to the collection never changes unless any of the following mut-methods is called:
@@ -208,6 +210,14 @@ pub trait PinnedVec<T> {
     /// - `new_len` must be less than or equal to `capacity()`.
     /// - The elements at `old_len..new_len` must be initialized.
     unsafe fn set_len(&mut self, new_len: usize);
+
+    /// Attempts to increase the capacity of the pinned vector with default additional amount defined by the specific implementation.
+    ///
+    /// The method:
+    /// * ensures that all already allocated elements stay pinned their memory locations,
+    /// * and returns the new capacity which is greater than or equal to the current capacity if the operation succeeds,
+    /// * corresponding `Err` if it fails.
+    fn try_grow(&mut self) -> Result<usize, PinnedVecGrowthError>;
 }
 
 #[cfg(test)]

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -22,6 +22,8 @@ pub fn test_pinned_vec<P: PinnedVec<usize>>(pinned_vec: P, test_vec_len: usize) 
 
 #[cfg(test)]
 mod tests {
+    use crate::PinnedVecGrowthError;
+
     use super::*;
 
     #[derive(Debug)]
@@ -141,6 +143,10 @@ mod tests {
 
         unsafe fn set_len(&mut self, new_len: usize) {
             self.0.set_len(new_len)
+        }
+
+        fn try_grow(&mut self) -> Result<usize, PinnedVecGrowthError> {
+            Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
         }
     }
 

--- a/src/pinned_vec_tests/testvec.rs
+++ b/src/pinned_vec_tests/testvec.rs
@@ -1,4 +1,4 @@
-use crate::PinnedVec;
+use crate::*;
 use std::iter::Rev;
 
 pub struct TestVec<T>(Vec<T>);
@@ -132,5 +132,9 @@ impl<T> PinnedVec<T> for TestVec<T> {
 
     unsafe fn set_len(&mut self, new_len: usize) {
         self.0.set_len(new_len)
+    }
+
+    fn try_grow(&mut self) -> Result<usize, PinnedVecGrowthError> {
+        Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
     }
 }


### PR DESCRIPTION
`try_grow` to increase the capacity of the pinned vector with default additional amount defined by the specific implementation. It is not guaranteed that the pinned vector will succeed while keeping the elements pinned to their locations; and hence, will return a result.