### PR TITLE
`grow_to` method is defined

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -218,6 +218,18 @@ pub trait PinnedVec<T> {
     /// * and returns the new capacity which is greater than or equal to the current capacity if the operation succeeds,
     /// * corresponding `Err` if it fails.
     fn try_grow(&mut self) -> Result<usize, PinnedVecGrowthError>;
+
+    /// Increases the capacity of the vector at least up to the `new_capacity`:
+    /// * has no affect if `new_capacity <= self.capacity()`, and returns `Ok(self.capacity())`;
+    /// * increases the capacity to `x >= new_capacity` otherwise if the operation succeeds.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe due to the internal guarantees of pinned vectors.
+    /// * A `SplitVec`, on the other hand, can grow to the `new_capacity` without any problem.
+    /// However, it is not designed to have intermediate empty fragments, while `grow_to` can leave such fragments.
+    /// Hence, the caller is responsible for handling this.
+    unsafe fn grow_to(&mut self, new_capacity: usize) -> Result<usize, PinnedVecGrowthError>;
 }
 
 #[cfg(test)]

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -22,9 +22,9 @@ pub fn test_pinned_vec<P: PinnedVec<usize>>(pinned_vec: P, test_vec_len: usize) 
 
 #[cfg(test)]
 mod tests {
-    use crate::PinnedVecGrowthError;
 
     use super::*;
+    use crate::PinnedVecGrowthError;
 
     #[derive(Debug)]
     struct JustVec<T>(Vec<T>);
@@ -146,6 +146,10 @@ mod tests {
         }
 
         fn try_grow(&mut self) -> Result<usize, PinnedVecGrowthError> {
+            Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
+        }
+
+        unsafe fn grow_to(&mut self, _: usize) -> Result<usize, PinnedVecGrowthError> {
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
         }
     }

--- a/src/pinned_vec_tests/testvec.rs
+++ b/src/pinned_vec_tests/testvec.rs
@@ -137,4 +137,8 @@ impl<T> PinnedVec<T> for TestVec<T> {
     fn try_grow(&mut self) -> Result<usize, PinnedVecGrowthError> {
         Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
     }
+
+    unsafe fn grow_to(&mut self, _: usize) -> Result<usize, PinnedVecGrowthError> {
+        Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
+    }
 }


### PR DESCRIPTION
`grow_to` method is defined. This method allows the pinned vector to reserve memory for a possibly succeeding batch write operations.