### PR TITLE
Support for Concurrency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/README.md
+++ b/README.md
@@ -38,11 +38,9 @@ Note that `std::vec::Vec` does not provide the pinned elements during growth gua
 
 There are various situations where pinned elements are necessary.
 
-* It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details.
-* It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` avoids heap allocations and wide pointers such as `Box` or `Rc` or etc.
-* It is important for **async** code; following [blog](https://blog.cloudflare.com/pin-and-unpin-in-rust) could be useful for the interested.
-
-*As explained in [rust-docs](https://doc.rust-lang.org/std/pin/index.html), there exist `Pin` and `Unpin` types for similar purposes. However, the solution is complicated and low level using `PhantomPinned`, `NonNull`, `dangling`, `Box::pin`, pointer accesses, etc.*
+* It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details, and its special cases such as [`LinkedList`](https://crates.io/crates/orx-linked-list).
+* It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` allows avoiding certain borrow checker complexities, heap allocations and wide pointers such as `Box` or `Rc` or etc.
+* It is important for **concurrent** programs since it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency. [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is a very simplistic and efficient concurrent data structure built on top of pinned vector guarantees.
 
 ## C. Implementations
 

--- a/src/capacity.rs
+++ b/src/capacity.rs
@@ -1,0 +1,90 @@
+/// Provides detailed information of capacity state of the pinned vector.
+///
+/// This information contains the current capacity which can be obtained by `capacity()` method and extends with additional useful information.
+///
+/// * `FixedCapacity` variant only provides the current capacity.
+/// However, its additional tag informs that this capacity is a hard constraint and the vector cannot grow beyond it.
+/// * `DynamicCapacity` variant informs that the vector is capable of allocating and growing its capacity.
+/// It provides `current_capacity` representing the current internal state of the vector.
+/// Additionally, `maximum_concurrent_capacity` is provided.
+/// This number represents the maximum number of elements that can safely be pushed to the vector in a concurrent program.
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub enum CapacityState {
+    /// `FixedCapacity` variant only provides the current capacity.
+    /// However, its additional tag informs that this capacity is a hard constraint and the vector cannot grow beyond it.
+    FixedCapacity(usize),
+    /// `DynamicCapacity` variant informs that the vector is capable of allocating and growing its capacity.
+    /// It provides `current_capacity` representing the current internal state of the vector.
+    /// Additionally, `maximum_concurrent_capacity` is provided.
+    /// This number represents the maximum number of elements that can safely be pushed to the vector in a concurrent program.
+    /// This value is often related with the capacity of the container holding meta information about allocations.
+    /// Note that the dynamic vector can naturally grow beyond this number, this bound is only relevant when the vector is `Sync`ed among threads.
+    DynamicCapacity {
+        /// Capacity of current allocations owned by the vector.
+        current_capacity: usize,
+        /// Maximum capacity that can safely be reached by the vector in a concurrent program.
+        /// This value is often related with the capacity of the container holding meta information about allocations.
+        /// Note that the dynamic vector can naturally grow beyond this number, this bound is only relevant when the vector is `Sync`ed among threads.
+        maximum_concurrent_capacity: usize,
+    },
+}
+
+impl CapacityState {
+    /// Capacity of current allocations owned by the vector.
+    pub fn current_capacity(&self) -> usize {
+        match self {
+            Self::FixedCapacity(x) => *x,
+            Self::DynamicCapacity {
+                current_capacity,
+                maximum_concurrent_capacity: _,
+            } => *current_capacity,
+        }
+    }
+
+    /// Maximum capacity that can safely be reached by the vector in a concurrent program.
+    /// This value is often related with the capacity of the container holding meta information about allocations.
+    /// Note that the dynamic vector can naturally grow beyond this number, this bound is only relevant when the vector is `Sync`ed among threads.
+    pub fn maximum_concurrent_capacity(&self) -> usize {
+        match self {
+            Self::FixedCapacity(x) => *x,
+            Self::DynamicCapacity {
+                current_capacity: _,
+                maximum_concurrent_capacity,
+            } => *maximum_concurrent_capacity,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_capacity() {
+        assert_eq!(42, CapacityState::FixedCapacity(42).current_capacity());
+        assert_eq!(
+            7,
+            CapacityState::DynamicCapacity {
+                current_capacity: 7,
+                maximum_concurrent_capacity: 42
+            }
+            .current_capacity()
+        );
+    }
+
+    #[test]
+    fn maximum_concurrent_capacity() {
+        assert_eq!(
+            42,
+            CapacityState::FixedCapacity(42).maximum_concurrent_capacity()
+        );
+        assert_eq!(
+            42,
+            CapacityState::DynamicCapacity {
+                current_capacity: 7,
+                maximum_concurrent_capacity: 42
+            }
+            .maximum_concurrent_capacity()
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,11 +38,9 @@
 //!
 //! There are various situations where pinned elements are necessary.
 //!
-//! * It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details.
-//! * It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` avoids heap allocations and wide pointers such as `Box` or `Rc` or etc.
-//! * It is important for **async** code; following [blog](https://blog.cloudflare.com/pin-and-unpin-in-rust) could be useful for the interested.
-//!
-//! *As explained in [rust-docs](https://doc.rust-lang.org/std/pin/index.html), there exist `Pin` and `Unpin` types for similar purposes. However, the solution is complicated and low level using `PhantomPinned`, `NonNull`, `dangling`, `Box::pin`, pointer accesses, etc.*
+//! * It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details, and its special cases such as [`LinkedList`](https://crates.io/crates/orx-linked-list).
+//! * It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` allows avoiding certain borrow checker complexities, heap allocations and wide pointers such as `Box` or `Rc` or etc.
+//! * It is important for **concurrent** programs since it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency. [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is a very simplistic and efficient concurrent data structure built on top of pinned vector guarantees.
 //!
 //! ## C. Implementations
 //!
@@ -64,12 +62,14 @@
     clippy::todo
 )]
 
+mod capacity;
 mod errors;
 mod pinned_vec;
 mod pinned_vec_tests;
 /// Utility functions to make PinnedVec implementations more convenient.
 pub mod utils;
 
+pub use capacity::CapacityState;
 pub use errors::PinnedVecGrowthError;
 pub use pinned_vec::PinnedVec;
 pub use pinned_vec_tests::test_all::test_pinned_vec;

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -1,4 +1,4 @@
-use crate::errors::PinnedVecGrowthError;
+use crate::{errors::PinnedVecGrowthError, CapacityState};
 
 /// Trait for vector representations differing from `std::vec::Vec` by the following:
 ///
@@ -89,8 +89,15 @@ pub trait PinnedVec<T> {
     /// * we cannot keep holding a reference to a vector element defined aliased the `clear` call,
     /// since `clear` requires a `mut` reference.
     fn clear(&mut self);
+
     /// Returns the total number of elements the vector can hold without reallocating.
     fn capacity(&self) -> usize;
+
+    /// Provides detailed information of capacity state of the pinned vector.
+    ///
+    /// This information contains the current capacity which can be obtained by [`PinnedVec::capacity()`] method and extends with additional useful information.
+    fn capacity_state(&self) -> CapacityState;
+
     /// Clones and appends all elements in a slice to the Vec.
     ///
     /// Iterates over `other`, clones each element, and then appends it to this vec. The other slice is traversed in-order.
@@ -230,6 +237,27 @@ pub trait PinnedVec<T> {
     /// However, it is not designed to have intermediate empty fragments, while `grow_to` can leave such fragments.
     /// Hence, the caller is responsible for handling this.
     unsafe fn grow_to(&mut self, new_capacity: usize) -> Result<usize, PinnedVecGrowthError>;
+
+    /// Increases the capacity of the vector at least up to the `new_capacity`:
+    /// * has no affect if `new_capacity <= self.capacity()`, and returns `Ok(self.capacity())`;
+    /// * increases the capacity to `x >= new_capacity` otherwise if the operation succeeds.
+    ///
+    /// It differs from `grow_to` method by the following:
+    /// * as all `PinnedVec` methods, `grow_to` is responsible for keeping elements pinned to their locations;
+    /// * while `concurrently_grow_to` provides additional guarantees so that meta information storing memory locations of the elements also keep pinned to their locations.
+    ///
+    /// This additional guarantee is irrelevant for single-threaded programs, while critical for concurrent programs.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe due to the internal guarantees of pinned vectors.
+    /// * A `SplitVec`, on the other hand, can grow to the `new_capacity` without any problem.
+    /// However, it is not designed to have intermediate empty fragments, while `grow_to` can leave such fragments.
+    /// Hence, the caller is responsible for handling this.
+    unsafe fn concurrently_grow_to(
+        &mut self,
+        new_capacity: usize,
+    ) -> Result<usize, PinnedVecGrowthError>;
 }
 
 #[cfg(test)]

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -24,7 +24,7 @@ pub fn test_pinned_vec<P: PinnedVec<usize>>(pinned_vec: P, test_vec_len: usize) 
 mod tests {
 
     use super::*;
-    use crate::PinnedVecGrowthError;
+    use crate::{CapacityState, PinnedVecGrowthError};
 
     #[derive(Debug)]
     struct JustVec<T>(Vec<T>);
@@ -48,6 +48,10 @@ mod tests {
 
         fn capacity(&self) -> usize {
             self.0.capacity()
+        }
+
+        fn capacity_state(&self) -> CapacityState {
+            CapacityState::FixedCapacity(self.capacity())
         }
 
         fn extend_from_slice(&mut self, other: &[T])
@@ -150,6 +154,10 @@ mod tests {
         }
 
         unsafe fn grow_to(&mut self, _: usize) -> Result<usize, PinnedVecGrowthError> {
+            Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
+        }
+
+        unsafe fn concurrently_grow_to(&mut self, _: usize) -> Result<usize, PinnedVecGrowthError> {
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
         }
     }

--- a/src/pinned_vec_tests/testvec.rs
+++ b/src/pinned_vec_tests/testvec.rs
@@ -36,6 +36,10 @@ impl<T> PinnedVec<T> for TestVec<T> {
         self.0.capacity()
     }
 
+    fn capacity_state(&self) -> CapacityState {
+        CapacityState::FixedCapacity(self.capacity())
+    }
+
     fn extend_from_slice(&mut self, other: &[T])
     where
         T: Clone,
@@ -139,6 +143,10 @@ impl<T> PinnedVec<T> for TestVec<T> {
     }
 
     unsafe fn grow_to(&mut self, _: usize) -> Result<usize, PinnedVecGrowthError> {
+        Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
+    }
+
+    unsafe fn concurrently_grow_to(&mut self, _: usize) -> Result<usize, PinnedVecGrowthError> {
         Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
     }
 }


### PR DESCRIPTION
* `CapacityState` is defined.
  * Capacity state returns capacity information which is more detailed than a `usize`.
  * It tells if and how the vector can grow.
  * These details are important in managing growth with pinned elements in a concurrent program.
* `concurrently_grow_to` method is defined.
  * This method is similar to the `grow_to` method.
  * However, it requires additional guarantee that meta information storing memory locations of the pinned elements also keep pinned to their locations.