### PR TITLE
grow_to methods accepts `zero_memory` argument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "2.6.0"
+version = "2.7.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -230,13 +230,20 @@ pub trait PinnedVec<T> {
     /// * has no affect if `new_capacity <= self.capacity()`, and returns `Ok(self.capacity())`;
     /// * increases the capacity to `x >= new_capacity` otherwise if the operation succeeds.
     ///
+    /// When `zero_memory` is set to true, the pinned vector will zero out the new allocated memory
+    /// corresponding to positions starting from `self.len()` to `new_capacity`.
+    ///
     /// # Safety
     ///
     /// This method is unsafe due to the internal guarantees of pinned vectors.
     /// * A `SplitVec`, on the other hand, can grow to the `new_capacity` without any problem.
     /// However, it is not designed to have intermediate empty fragments, while `grow_to` can leave such fragments.
     /// Hence, the caller is responsible for handling this.
-    unsafe fn grow_to(&mut self, new_capacity: usize) -> Result<usize, PinnedVecGrowthError>;
+    unsafe fn grow_to(
+        &mut self,
+        new_capacity: usize,
+        zero_memory: bool,
+    ) -> Result<usize, PinnedVecGrowthError>;
 
     /// Increases the capacity of the vector at least up to the `new_capacity`:
     /// * has no affect if `new_capacity <= self.capacity()`, and returns `Ok(self.capacity())`;
@@ -248,6 +255,9 @@ pub trait PinnedVec<T> {
     ///
     /// This additional guarantee is irrelevant for single-threaded programs, while critical for concurrent programs.
     ///
+    /// When `zero_memory` is set to true, the pinned vector will zero out the new allocated memory
+    /// corresponding to positions starting from `self.len()` to `new_capacity`.
+    ///
     /// # Safety
     ///
     /// This method is unsafe due to the internal guarantees of pinned vectors.
@@ -257,6 +267,7 @@ pub trait PinnedVec<T> {
     unsafe fn concurrently_grow_to(
         &mut self,
         new_capacity: usize,
+        zero_memory: bool,
     ) -> Result<usize, PinnedVecGrowthError>;
 }
 

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -153,11 +153,15 @@ mod tests {
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
         }
 
-        unsafe fn grow_to(&mut self, _: usize) -> Result<usize, PinnedVecGrowthError> {
+        unsafe fn grow_to(&mut self, _: usize, _: bool) -> Result<usize, PinnedVecGrowthError> {
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
         }
 
-        unsafe fn concurrently_grow_to(&mut self, _: usize) -> Result<usize, PinnedVecGrowthError> {
+        unsafe fn concurrently_grow_to(
+            &mut self,
+            _: usize,
+            _: bool,
+        ) -> Result<usize, PinnedVecGrowthError> {
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
         }
     }

--- a/src/pinned_vec_tests/testvec.rs
+++ b/src/pinned_vec_tests/testvec.rs
@@ -142,11 +142,15 @@ impl<T> PinnedVec<T> for TestVec<T> {
         Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
     }
 
-    unsafe fn grow_to(&mut self, _: usize) -> Result<usize, PinnedVecGrowthError> {
+    unsafe fn grow_to(&mut self, _: usize, _: bool) -> Result<usize, PinnedVecGrowthError> {
         Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
     }
 
-    unsafe fn concurrently_grow_to(&mut self, _: usize) -> Result<usize, PinnedVecGrowthError> {
+    unsafe fn concurrently_grow_to(
+        &mut self,
+        _: usize,
+        _: bool,
+    ) -> Result<usize, PinnedVecGrowthError> {
         Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
     }
 }


### PR DESCRIPTION
The users of the `PinnedVec` trait might sometimes require to zero out allocated memory which is not yet written. This is an additional safety guarantee for specifically concurrent data types. Therefore, `grow_to` and `concurrently_grow_to` methods accept a second argument `zero_memory`. When `true` is passed in, the implementor is responsible for zeroing out the new memory, if allocated.