### PR TITLE
`try_reserve_maximum_concurrent_capacity` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "2.7.0"
+version = "2.8.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -245,6 +245,8 @@ pub trait PinnedVec<T> {
         zero_memory: bool,
     ) -> Result<usize, PinnedVecGrowthError>;
 
+    // concurrency
+
     /// Increases the capacity of the vector at least up to the `new_capacity`:
     /// * has no affect if `new_capacity <= self.capacity()`, and returns `Ok(self.capacity())`;
     /// * increases the capacity to `x >= new_capacity` otherwise if the operation succeeds.
@@ -269,6 +271,16 @@ pub trait PinnedVec<T> {
         new_capacity: usize,
         zero_memory: bool,
     ) -> Result<usize, PinnedVecGrowthError>;
+
+    /// Tries to make sure that the pinned vector is capable of growing up to the given `new_maximum_capacity` safely in a concurrent execution.
+    /// Returns `Ok` of the new maximum capacity which is greater than or equal to the requested `new_maximum_capacity`; or the corresponding `Error` if the attempt fails.
+    ///
+    /// Importantly, note that this method does **not** lead to reserving memory for `new_maximum_capacity` elements.
+    /// It only makes sure that such an allocation will be possible with shared references which can be required in concurrent execution.
+    fn try_reserve_maximum_concurrent_capacity(
+        &mut self,
+        new_maximum_capacity: usize,
+    ) -> Result<usize, String>;
 }
 
 #[cfg(test)]

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -164,6 +164,13 @@ mod tests {
         ) -> Result<usize, PinnedVecGrowthError> {
             Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
         }
+
+        fn try_reserve_maximum_concurrent_capacity(
+            &mut self,
+            _new_maximum_capacity: usize,
+        ) -> Result<usize, String> {
+            Err("cannot reserve".to_string())
+        }
     }
 
     #[test]

--- a/src/pinned_vec_tests/testvec.rs
+++ b/src/pinned_vec_tests/testvec.rs
@@ -153,4 +153,11 @@ impl<T> PinnedVec<T> for TestVec<T> {
     ) -> Result<usize, PinnedVecGrowthError> {
         Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned)
     }
+
+    fn try_reserve_maximum_concurrent_capacity(
+        &mut self,
+        _new_maximum_capacity: usize,
+    ) -> Result<usize, String> {
+        Err("cannot reserve".to_string())
+    }
 }


### PR DESCRIPTION
`try_reserve_maximum_concurrent_capacity` method is defined which is essential for concurrent wrappers such as [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col).