### PR TITLE
IntoIterator is required

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "2.8.0"
+version = "2.9.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -25,7 +25,7 @@ use crate::{errors::PinnedVecGrowthError, CapacityState};
 /// | `pop()` | does not change the memory locations of the first `n-1` elements, the `n`-th element is removed |
 /// | `remove(a)` | does not change the memory locations of the first `a` elements, where `a < n`; elements to the right of the removed element might be changed, commonly shifted to left |
 /// | `truncate(a)` | does not change the memory locations of the first `a` elements, where `a < n` |
-pub trait PinnedVec<T> {
+pub trait PinnedVec<T>: IntoIterator<Item = T> {
     /// Iterator yielding references to the elements of the vector.
     type Iter<'a>: Iterator<Item = &'a T>
     where

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -28,6 +28,13 @@ mod tests {
 
     #[derive(Debug)]
     struct JustVec<T>(Vec<T>);
+    impl<T> IntoIterator for JustVec<T> {
+        type Item = T;
+        type IntoIter = <Vec<T> as IntoIterator>::IntoIter;
+        fn into_iter(self) -> Self::IntoIter {
+            self.0.into_iter()
+        }
+    }
     impl<T> PinnedVec<T> for JustVec<T> {
         type Iter<'a> = std::slice::Iter<'a, T> where T: 'a, Self: 'a;
         type IterMut<'a> = std::slice::IterMut<'a, T> where T: 'a, Self: 'a;

--- a/src/pinned_vec_tests/testvec.rs
+++ b/src/pinned_vec_tests/testvec.rs
@@ -14,6 +14,14 @@ impl<T> TestVec<T> {
     }
 }
 
+impl<T> IntoIterator for TestVec<T> {
+    type Item = T;
+    type IntoIter = <Vec<T> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 impl<T> PinnedVec<T> for TestVec<T> {
     type Iter<'a> = std::slice::Iter<'a, T> where T: 'a, Self: 'a;
     type IterMut<'a> = std::slice::IterMut<'a, T> where T: 'a, Self: 'a;


### PR DESCRIPTION
All pinned vectors must now implement `IntoIterator`.