### PR TITLE
`binary_search_by` is required for PinnedVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "2.9.0"
+version = "2.10.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/src/pinned_vec_tests/binary_search.rs
+++ b/src/pinned_vec_tests/binary_search.rs
@@ -1,0 +1,32 @@
+use crate::PinnedVec;
+
+pub fn binary_search<P: PinnedVec<usize>>(pinned_vec: P, max_allowed_test_len: usize) -> P {
+    let mut vec = pinned_vec;
+    vec.clear();
+
+    for i in 0..max_allowed_test_len {
+        vec.push(i);
+    }
+
+    let n = vec.len();
+
+    if n >= 42 {
+        assert_eq!(vec.binary_search(&42), Ok(42));
+        assert_eq!(vec.binary_search(&(n - 1)), Ok(n - 1));
+    }
+    assert_eq!(vec.binary_search(&n), Err(n));
+
+    if n >= 42 {
+        assert_eq!(vec.binary_search_by_key(&84, |x| x * 2), Ok(42));
+        assert_eq!(vec.binary_search_by_key(&(2 * n - 2), |x| x * 2), Ok(n - 1));
+    }
+    assert_eq!(vec.binary_search_by_key(&(2 * n), |x| x * 2), Err(n));
+
+    if n >= 42 {
+        assert_eq!(vec.binary_search_by(|x| x.cmp(&42)), Ok(42));
+        assert_eq!(vec.binary_search_by(|x| x.cmp(&(n - 1))), Ok(n - 1));
+    }
+    assert_eq!(vec.binary_search_by(|x| x.cmp(&n)), Err(n));
+
+    vec
+}

--- a/src/pinned_vec_tests/mod.rs
+++ b/src/pinned_vec_tests/mod.rs
@@ -1,3 +1,4 @@
+mod binary_search;
 mod extend;
 mod insert;
 mod pop;
@@ -5,7 +6,8 @@ mod push;
 mod refmap;
 mod remove;
 pub mod test_all;
-#[cfg(test)]
-pub(crate) mod testvec;
 mod truncate;
 mod unsafe_writer;
+
+#[cfg(test)]
+pub(crate) mod testvec;

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -17,6 +17,7 @@ pub fn test_pinned_vec<P: PinnedVec<usize>>(pinned_vec: P, test_vec_len: usize) 
     let pinned_vec = super::pop::pop(pinned_vec, test_vec_len);
     let pinned_vec = super::remove::remove(pinned_vec, test_vec_len);
     let pinned_vec = super::truncate::truncate(pinned_vec, test_vec_len);
+    let pinned_vec = super::binary_search::binary_search(pinned_vec, test_vec_len);
     let _ = super::unsafe_writer::unsafe_writer(pinned_vec, test_vec_len);
 }
 
@@ -25,6 +26,7 @@ mod tests {
 
     use super::*;
     use crate::{CapacityState, PinnedVecGrowthError};
+    use std::cmp::Ordering;
 
     #[derive(Debug)]
     struct JustVec<T>(Vec<T>);
@@ -154,6 +156,13 @@ mod tests {
 
         unsafe fn set_len(&mut self, new_len: usize) {
             self.0.set_len(new_len)
+        }
+
+        fn binary_search_by<F>(&self, f: F) -> Result<usize, usize>
+        where
+            F: FnMut(&T) -> Ordering,
+        {
+            self.0.binary_search_by(f)
         }
 
         fn try_grow(&mut self) -> Result<usize, PinnedVecGrowthError> {

--- a/src/pinned_vec_tests/testvec.rs
+++ b/src/pinned_vec_tests/testvec.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use std::iter::Rev;
+use std::{cmp::Ordering, iter::Rev};
 
 pub struct TestVec<T>(Vec<T>);
 
@@ -144,6 +144,13 @@ impl<T> PinnedVec<T> for TestVec<T> {
 
     unsafe fn set_len(&mut self, new_len: usize) {
         self.0.set_len(new_len)
+    }
+
+    fn binary_search_by<F>(&self, f: F) -> Result<usize, usize>
+    where
+        F: FnMut(&T) -> Ordering,
+    {
+        self.0.binary_search_by(f)
     }
 
     fn try_grow(&mut self) -> Result<usize, PinnedVecGrowthError> {


### PR DESCRIPTION
* Default implementations of `binary_search` and `binary_search_by_key` are provided.
* Binary search methods are added to to pinned vector tests.