### PR TITLE
slices and initialized grow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "2.10.0"
+version = "2.11.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Note that `std::vec::Vec` does not provide the pinned elements during growth gua
 
 ## B. Motivation
 
-There are various situations where pinned elements are necessary.
+There are various situations where pinned elements are critical.
 
 * It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details, and its special cases such as [`LinkedList`](https://crates.io/crates/orx-linked-list).
+* It is important for **concurrent** programs as it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency, and leads to efficient concurrent data structures. See [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter), [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) or [`ConcurrentOrderedBag`](https://crates.io/crates/orx-concurrent-ordered-bag) for such concurrent data structures which are conveniently built on the pinned element guarantees of pinned vectors.
 * It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` allows avoiding certain borrow checker complexities, heap allocations and wide pointers such as `Box` or `Rc` or etc.
-* It is important for **concurrent** programs since it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency. [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is a very simplistic and efficient concurrent data structure built on top of pinned vector guarantees.
 
 ## C. Implementations
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,11 @@
 //!
 //! ## B. Motivation
 //!
-//! There are various situations where pinned elements are necessary.
+//! There are various situations where pinned elements are critical.
 //!
 //! * It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details, and its special cases such as [`LinkedList`](https://crates.io/crates/orx-linked-list).
+//! * It is important for **concurrent** programs as it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency, and leads to efficient concurrent data structures. See [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter), [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) or [`ConcurrentOrderedBag`](https://crates.io/crates/orx-concurrent-ordered-bag) for such concurrent data structures which are conveniently built on the pinned element guarantees of pinned vectors.
 //! * It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` allows avoiding certain borrow checker complexities, heap allocations and wide pointers such as `Box` or `Rc` or etc.
-//! * It is important for **concurrent** programs since it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency. [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is a very simplistic and efficient concurrent data structure built on top of pinned vector guarantees.
 //!
 //! ## C. Implementations
 //!

--- a/src/pinned_vec_tests/grow_and_initialize.rs
+++ b/src/pinned_vec_tests/grow_and_initialize.rs
@@ -1,0 +1,101 @@
+use crate::PinnedVec;
+
+pub fn grow<P: PinnedVec<usize>>(pinned_vec: P, max_allowed_test_len: usize) -> P {
+    let mut vec = pinned_vec;
+
+    // empty - no growth
+    vec.clear();
+    let cap = vec.capacity();
+    let new_cap = vec.grow_and_initialize(0, || 444444).expect("must succeed");
+    assert_eq!(new_cap, cap);
+    assert_eq!(vec.len(), cap);
+    assert_eq!(vec.capacity(), cap);
+
+    // empty - growth
+    vec.clear();
+    let cap = vec.capacity();
+    let req_cap = 56.min(max_allowed_test_len);
+    let new_cap = vec
+        .grow_and_initialize(req_cap, || 444444)
+        .expect("must succeed");
+    assert!(new_cap >= req_cap);
+    assert!(new_cap >= cap);
+    assert_eq!(vec.capacity(), new_cap);
+    assert_eq!(vec.len(), new_cap);
+    for i in 0..cap {
+        assert_eq!(vec.get(i), Some(&444444));
+    }
+
+    // half full - no growth
+    vec.clear();
+    for i in 0..22.min(max_allowed_test_len) {
+        vec.push(i);
+    }
+    let (len, cap) = (vec.len(), vec.capacity());
+    let new_cap = vec.grow_and_initialize(0, || 444444).expect("must succeed");
+    assert_eq!(new_cap, cap);
+    assert_eq!(vec.len(), cap);
+    assert_eq!(vec.capacity(), cap);
+    for i in 0..len {
+        assert_eq!(vec.get(i), Some(&i));
+    }
+    for i in len..cap {
+        assert_eq!(vec.get(i), Some(&444444));
+    }
+
+    // half full - growth
+    vec.clear();
+    for i in 0..22.min(max_allowed_test_len) {
+        vec.push(i);
+    }
+    let (len, cap) = (vec.len(), vec.capacity());
+    let req_cap = 56.min(max_allowed_test_len);
+    let new_cap = vec
+        .grow_and_initialize(req_cap, || 444444)
+        .expect("must succeed");
+    assert!(new_cap >= req_cap);
+    assert!(new_cap >= cap);
+    assert_eq!(vec.capacity(), new_cap);
+    assert_eq!(vec.len(), new_cap);
+    for i in 0..len {
+        assert_eq!(vec.get(i), Some(&i));
+    }
+    for i in len..cap {
+        assert_eq!(vec.get(i), Some(&444444));
+    }
+
+    vec
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pinned_vec_tests::testvec::TestVec;
+
+    #[test]
+    fn test_pop_empty() {
+        let pinned_vec = TestVec::new(0);
+        grow(pinned_vec, 0);
+    }
+
+    #[test]
+    fn test_pop_small() {
+        let capacity = 40;
+        let pinned_vec = TestVec::new(capacity);
+        grow(pinned_vec, capacity);
+    }
+
+    #[test]
+    fn test_pop_medium() {
+        let capacity = 1024 * 64;
+        let pinned_vec = TestVec::new(capacity);
+        grow(pinned_vec, capacity);
+    }
+
+    #[test]
+    fn test_pop_large() {
+        let capacity = 1024 * 1024;
+        let pinned_vec = TestVec::new(capacity);
+        grow(pinned_vec, capacity);
+    }
+}

--- a/src/pinned_vec_tests/helpers/mod.rs
+++ b/src/pinned_vec_tests/helpers/mod.rs
@@ -1,0 +1,1 @@
+pub mod range;

--- a/src/pinned_vec_tests/helpers/range.rs
+++ b/src/pinned_vec_tests/helpers/range.rs
@@ -1,0 +1,16 @@
+use std::ops::RangeBounds;
+
+pub(crate) fn range_start<R: RangeBounds<usize>>(range: &R) -> usize {
+    match range.start_bound() {
+        std::ops::Bound::Excluded(x) => x + 1,
+        std::ops::Bound::Included(x) => *x,
+        std::ops::Bound::Unbounded => 0,
+    }
+}
+pub(crate) fn range_end<R: RangeBounds<usize>>(range: &R, vec_len: usize) -> usize {
+    match range.end_bound() {
+        std::ops::Bound::Excluded(x) => *x,
+        std::ops::Bound::Included(x) => x + 1,
+        std::ops::Bound::Unbounded => vec_len,
+    }
+}

--- a/src/pinned_vec_tests/mod.rs
+++ b/src/pinned_vec_tests/mod.rs
@@ -1,13 +1,17 @@
 mod binary_search;
 mod extend;
+mod grow_and_initialize;
 mod insert;
 mod pop;
 mod push;
 mod refmap;
 mod remove;
+mod slices;
 pub mod test_all;
 mod truncate;
 mod unsafe_writer;
 
+#[cfg(test)]
+mod helpers;
 #[cfg(test)]
 pub(crate) mod testvec;

--- a/src/pinned_vec_tests/slices.rs
+++ b/src/pinned_vec_tests/slices.rs
@@ -1,0 +1,144 @@
+use crate::PinnedVec;
+
+pub fn slices<P: PinnedVec<usize>>(pinned_vec: P, max_allowed_test_len: usize) -> P {
+    let vec = slice(pinned_vec, max_allowed_test_len);
+    slice_mut(vec, max_allowed_test_len)
+}
+
+fn slice<P: PinnedVec<usize>>(pinned_vec: P, max_allowed_test_len: usize) -> P {
+    let mut vec = pinned_vec;
+    vec.clear();
+
+    for i in 0..max_allowed_test_len {
+        vec.push(i);
+    }
+
+    for i in (0..vec.len()).step_by(41) {
+        let slice = vec.slices(0..i);
+        let mut val = 0;
+        for s in slice {
+            for x in s {
+                assert_eq!(*x, val);
+                val += 1;
+            }
+        }
+        assert_eq!(i, val);
+    }
+
+    for i in (0..vec.len()).step_by(17) {
+        let slice = vec.slices(i..max_allowed_test_len);
+        let mut val = i;
+        for s in slice {
+            for x in s {
+                assert_eq!(*x, val);
+                val += 1;
+            }
+        }
+    }
+
+    let ranges = [
+        (10, max_allowed_test_len),
+        (10, max_allowed_test_len / 2),
+        (10, max_allowed_test_len / 4),
+        (10, max_allowed_test_len / 8),
+        (100, max_allowed_test_len),
+        (100, max_allowed_test_len / 2),
+        (100, max_allowed_test_len / 4),
+        (100, max_allowed_test_len / 8),
+    ];
+
+    for (b, e) in ranges {
+        let len = e.saturating_sub(b);
+        let slice = vec.slices(b..e);
+        let mut val = b;
+        for s in slice {
+            for x in s {
+                assert_eq!(*x, val);
+                val += 1;
+            }
+        }
+        assert_eq!(len, val - b);
+    }
+
+    vec
+}
+
+fn slice_mut<P: PinnedVec<usize>>(pinned_vec: P, max_allowed_test_len: usize) -> P {
+    let mut vec = pinned_vec;
+    vec.clear();
+
+    for i in 0..max_allowed_test_len {
+        vec.push(i);
+    }
+
+    for i in (0..vec.len()).step_by(41) {
+        let slice = vec.slices_mut(0..i);
+        let mut val = 0;
+        for s in slice {
+            for x in s {
+                assert_eq!(*x, val);
+                val += 1;
+            }
+        }
+        assert_eq!(i, val);
+    }
+
+    for i in (0..vec.len()).step_by(17) {
+        let slice = vec.slices_mut(i..max_allowed_test_len);
+        let mut val = i;
+        for s in slice {
+            for x in s {
+                assert_eq!(*x, val);
+                val += 1;
+            }
+        }
+    }
+
+    let ranges = [
+        (10, max_allowed_test_len),
+        (10, max_allowed_test_len / 2),
+        (10, max_allowed_test_len / 4),
+        (10, max_allowed_test_len / 8),
+        (100, max_allowed_test_len),
+        (100, max_allowed_test_len / 2),
+        (100, max_allowed_test_len / 4),
+        (100, max_allowed_test_len / 8),
+    ];
+
+    for (b, e) in ranges {
+        let len = e.saturating_sub(b);
+        let slice = vec.slices_mut(b..e);
+        let mut val = b;
+        for s in slice {
+            for x in s {
+                assert_eq!(*x, val);
+                val += 1;
+            }
+        }
+        assert_eq!(len, val - b);
+    }
+
+    let mut fill = |b: usize, e: usize| {
+        let slice = vec.slices_mut(b..e);
+        let mut val = b;
+        for s in slice {
+            for x in s {
+                *x = 10 * val;
+                val += 1;
+            }
+        }
+    };
+    fill(0, max_allowed_test_len);
+    fill(0, 10);
+    fill(10, 30);
+    fill(30, 178);
+    fill(178, 333);
+    fill(333, 482);
+    fill(333, max_allowed_test_len);
+
+    for i in 0..max_allowed_test_len {
+        assert_eq!(vec.get(i), Some(&(10 * i)));
+    }
+
+    vec
+}


### PR DESCRIPTION
Two slice returning methods are introduced. These methods are important in performant critical applications which allows to directly benefit from slice optimizations.
* `fn slices(&self, range: R)` returns an iterator of slices representing a given range of the vector.
* `fn slices_mut(&mut self, range: R)` returns a mutable iterator of slices representing a given range of the vector.

A concurrently safe growth method method `grow_and_initialize` is introduced. This methods performs capacity growth and length growth at the same time making sure that all elements are initialized with valid values.

Test methods are extended accordingly.