### PR TITLE
slices iterators require Default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "2.11.0"
+version = "2.12.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -49,13 +49,13 @@ pub trait PinnedVec<T>: IntoIterator<Item = T> {
         Self: 'a;
 
     /// Iterator yielding slices corresponding to a range of indices, returned by the `slice` method.
-    type SliceIter<'a>: IntoIterator<Item = &'a [T]>
+    type SliceIter<'a>: IntoIterator<Item = &'a [T]> + Default
     where
         T: 'a,
         Self: 'a;
 
     /// Iterator yielding mutable slices corresponding to a range of indices, returned by the `slice_mut` and `slice_mut_unchecked` methods.
-    type SliceMutIter<'a>: IntoIterator<Item = &'a mut [T]>
+    type SliceMutIter<'a>: IntoIterator<Item = &'a mut [T]> + Default
     where
         T: 'a,
         Self: 'a;


### PR DESCRIPTION
This bound is useful in returning empty iterators; or an empty slice.