### PR TITLE
fill-with variants to initialize memory on growth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."
@@ -10,4 +10,4 @@ keywords = ["vec", "array", "vector", "pinned", "memory"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pseudo-default = "1.2.0"
+orx-pseudo-default = "1.2"

--- a/src/into_concurrent_pinned_vec.rs
+++ b/src/into_concurrent_pinned_vec.rs
@@ -7,4 +7,14 @@ pub trait IntoConcurrentPinnedVec<T>: PinnedVec<T> {
 
     /// Converts the pinned vector into its concurrent wrapper.
     fn into_concurrent(self) -> Self::ConPinnedVec;
+
+    /// Converts the pinned vector into its concurrent wrapper.
+    /// During conversion:
+    ///
+    /// * length of the vector is increased to its capacity;
+    /// * the elements in the range `len..capacity` are filled with the values
+    /// obtained by repeatedly calling the function `fill_with`.
+    fn into_concurrent_filled_with<F>(self, fill_with: F) -> Self::ConPinnedVec
+    where
+        F: Fn() -> T;
 }


### PR DESCRIPTION
`into_concurrent_filled_with` and `grow_to_and_fill_with` methods are required to enable data structures which always have an initialized and valid state.