### PR TITLE
clone_with_len and fill_with methods are defined for concurrent vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "3.5.0"
+version = "3.6.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."


### PR DESCRIPTION
* clone_with_len is required for thread safe cloning of data.
* fill_with, on the other hand, is required for data structures that needs to be gap-free all the time.