### PR TITLE
Support for self referential collections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "3.8.0"
+version = "3.9.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/src/capacity.rs
+++ b/src/capacity.rs
@@ -3,11 +3,11 @@
 /// This information contains the current capacity which can be obtained by `capacity()` method and extends with additional useful information.
 ///
 /// * `FixedCapacity` variant only provides the current capacity.
-/// However, its additional tag informs that this capacity is a hard constraint and the vector cannot grow beyond it.
+///   However, its additional tag informs that this capacity is a hard constraint and the vector cannot grow beyond it.
 /// * `DynamicCapacity` variant informs that the vector is capable of allocating and growing its capacity.
-/// It provides `current_capacity` representing the current internal state of the vector.
-/// Additionally, `maximum_concurrent_capacity` is provided.
-/// This number represents the maximum number of elements that can safely be pushed to the vector in a concurrent program.
+///   It provides `current_capacity` representing the current internal state of the vector.
+///   Additionally, `maximum_concurrent_capacity` is provided.
+///   This number represents the maximum number of elements that can safely be pushed to the vector in a concurrent program.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum CapacityState {
     /// `FixedCapacity` variant only provides the current capacity.

--- a/src/concurrent_pinned_vec.rs
+++ b/src/concurrent_pinned_vec.rs
@@ -120,7 +120,7 @@ pub trait ConcurrentPinnedVec<T> {
     ///
     /// * length of the vector is increased to its new capacity;
     /// * the elements in the range `len..capacity` are filled with the values
-    /// obtained by repeatedly calling the function `fill_with`.
+    ///   obtained by repeatedly calling the function `fill_with`.
     fn grow_to_and_fill_with<F>(
         &self,
         new_capacity: usize,

--- a/src/into_concurrent_pinned_vec.rs
+++ b/src/into_concurrent_pinned_vec.rs
@@ -13,7 +13,7 @@ pub trait IntoConcurrentPinnedVec<T>: PinnedVec<T> {
     ///
     /// * length of the vector is increased to its capacity;
     /// * the elements in the range `len..capacity` are filled with the values
-    /// obtained by repeatedly calling the function `fill_with`.
+    ///   obtained by repeatedly calling the function `fill_with`.
     fn into_concurrent_filled_with<F>(self, fill_with: F) -> Self::ConPinnedVec
     where
         F: Fn() -> T;

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -159,9 +159,9 @@ pub trait PinnedVec<T>:
     /// `clear` operation is **safe** both when `T: NotSelfRefVecItem` or not due to the following:
     ///
     /// * elements holding references to each other will be cleaned all together; hence,
-    /// none of them can have an invalid reference;
+    ///   none of them can have an invalid reference;
     /// * we cannot keep holding a reference to a vector element defined aliased the `clear` call,
-    /// since `clear` requires a `mut` reference.
+    ///   since `clear` requires a `mut` reference.
     fn clear(&mut self);
 
     /// Returns the total number of elements the vector can hold without reallocating.

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -80,6 +80,48 @@ pub trait PinnedVec<T>:
     /// * *O(f)* for [SplitVec](https://crates.io/crates/orx-split-vec) where f << n is the number of fragments.
     fn index_of(&self, element: &T) -> Option<usize>;
 
+    /// Returns the index of the `element_ptr` pointing to an element of the vec.
+    ///
+    /// The complexity of this method depends on the particular `PinnedVec` implementation.
+    /// However, making use of referential equality, it possible to perform much better than *O(n)*,
+    /// where n is the vector length.
+    ///
+    /// For the two example implementations, complexity of this method:
+    /// * *O(1)* for [FixedVec](https://crates.io/crates/orx-fixed-vec);
+    /// * *O(f)* for [SplitVec](https://crates.io/crates/orx-split-vec) where f << n is the number of fragments.
+    fn index_of_ptr(&self, element_ptr: *const T) -> Option<usize>;
+
+    /// Appends an element to the back of a collection and returns a pointer to its position in the vector.
+    fn push_get_ptr(&mut self, value: T) -> *const T;
+
+    /// Creates an iterator of the pointers to the elements of the vec.
+    ///
+    /// # Safety
+    ///
+    /// The implementor guarantees that the pointers are valid and belong to the elements of the vector.
+    /// However, the lifetime of the pointers might be extended by the caller;
+    /// i.e., it is not bound to the lifetime of `&self`.
+    ///
+    /// Therefore, the caller is responsible for making sure that the obtained pointers are still
+    /// valid before accessing through the pointers.
+    unsafe fn iter_ptr<'v, 'i>(&'v self) -> impl Iterator<Item = *const T> + 'i
+    where
+        T: 'i;
+
+    /// Creates a reverse iterator of the pointers to the elements of the vec, starting from the last element to the first.
+    ///
+    /// # Safety
+    ///
+    /// The implementor guarantees that the pointers are valid and belong to the elements of the vector.
+    /// However, the lifetime of the pointers might be extended by the caller;
+    /// i.e., it is not bound to the lifetime of `&self`.
+    ///
+    /// Therefore, the caller is responsible for making sure that the obtained pointers are still
+    /// valid before accessing through the pointers.
+    unsafe fn iter_ptr_rev<'v, 'i>(&'v self) -> impl Iterator<Item = *const T> + 'i
+    where
+        T: 'i;
+
     /// Returns whether or not of the `element` with the given reference belongs to this vector.
     /// In other words, returns whether or not the reference to the `element` is valid.
     ///
@@ -93,6 +135,19 @@ pub trait PinnedVec<T>:
     /// * *O(1)* for [FixedVec](https://crates.io/crates/orx-fixed-vec);
     /// * *O(f)* for [SplitVec](https://crates.io/crates/orx-split-vec) where f << n is the number of fragments.
     fn contains_reference(&self, element: &T) -> bool;
+
+    /// Returns whether or not of the element with the given pointer belongs to this vector.
+    ///
+    /// Note that `T: Eq` is not required; memory address is used.
+    ///
+    /// The complexity of this method depends on the particular `PinnedVec` implementation.
+    /// However, making use of pinned element guarantees, it possible to perform much better than *O(n)*,
+    /// where n is the vector length.
+    ///
+    /// For the two example implementations, complexity of this method:
+    /// * *O(1)* for [FixedVec](https://crates.io/crates/orx-fixed-vec);
+    /// * *O(f)* for [SplitVec](https://crates.io/crates/orx-split-vec) where f << n is the number of fragments.
+    fn contains_ptr(&self, element_ptr: *const T) -> bool;
 
     // vec
     /// Clears the vector, removing all values.
@@ -229,15 +284,15 @@ pub trait PinnedVec<T>:
     /// * returns an iterator yielding ordered slices that forms the required range when chained.
     fn slices_mut<R: RangeBounds<usize>>(&mut self, range: R) -> Self::SliceMutIter<'_>;
 
-    /// Returns a mutable reference to the `index`-th element of the vector.
+    /// Returns a pointer to the `index`-th element of the vector.
     ///
     /// Returns `None` if `index`-th position does not belong to the vector; i.e., if `index` is out of `capacity`.
+    fn get_ptr(&self, index: usize) -> Option<*const T>;
+
+    /// Returns a mutable pointer to the `index`-th element of the vector.
     ///
-    /// # Safety
-    ///
-    /// This method allows to write to a memory which is greater than the vector's length.
-    /// On the other hand, it will never return a pointer to a memory location that the vector does not own.
-    unsafe fn get_ptr_mut(&mut self, index: usize) -> Option<*mut T>;
+    /// Returns `None` if `index`-th position does not belong to the vector; i.e., if `index` is out of `capacity`.
+    fn get_ptr_mut(&mut self, index: usize) -> Option<*mut T>;
 
     /// Forces the length of the vector to `new_len`.
     ///

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -27,7 +27,7 @@ mod tests {
     use super::*;
     use crate::{
         pinned_vec_tests::helpers::range::{range_end, range_start},
-        CapacityState,
+        utils, CapacityState,
     };
     use alloc::vec::Vec;
     use core::{
@@ -86,8 +86,38 @@ mod tests {
             crate::utils::slice::index_of(&self.0, data)
         }
 
+        fn index_of_ptr(&self, element_ptr: *const T) -> Option<usize> {
+            crate::utils::slice::index_of_ptr(&self.0, element_ptr)
+        }
+
+        fn push_get_ptr(&mut self, value: T) -> *const T {
+            let idx = self.0.len();
+            self.0.push(value);
+            unsafe { self.0.as_ptr().add(idx) }
+        }
+
+        unsafe fn iter_ptr<'v, 'i>(&'v self) -> impl Iterator<Item = *const T> + 'i
+        where
+            T: 'i,
+        {
+            let ptr = self.0.as_ptr();
+            (0..self.0.len()).map(move |i| unsafe { ptr.add(i) })
+        }
+
+        unsafe fn iter_ptr_rev<'v, 'i>(&'v self) -> impl Iterator<Item = *const T> + 'i
+        where
+            T: 'i,
+        {
+            let ptr = self.0.as_ptr();
+            (0..self.0.len()).rev().map(move |i| unsafe { ptr.add(i) })
+        }
+
         fn contains_reference(&self, element: &T) -> bool {
-            self.index_of(element).is_some()
+            utils::slice::contains_reference(self.0.as_slice(), element)
+        }
+
+        fn contains_ptr(&self, element_ptr: *const T) -> bool {
+            utils::slice::contains_ptr(self.0.as_slice(), element_ptr)
         }
 
         fn clear(&mut self) {
@@ -216,12 +246,12 @@ mod tests {
             }
         }
 
-        unsafe fn get_ptr_mut(&mut self, index: usize) -> Option<*mut T> {
-            if index < self.0.capacity() {
-                Some(self.0.as_mut_ptr().add(index))
-            } else {
-                None
-            }
+        fn get_ptr(&self, index: usize) -> Option<*const T> {
+            (index < self.0.capacity()).then(|| unsafe { self.0.as_ptr().add(index) })
+        }
+
+        fn get_ptr_mut(&mut self, index: usize) -> Option<*mut T> {
+            (index < self.0.capacity()).then(|| unsafe { self.0.as_mut_ptr().add(index) })
         }
 
         unsafe fn set_len(&mut self, new_len: usize) {

--- a/src/pinned_vec_tests/unsafe_writer.rs
+++ b/src/pinned_vec_tests/unsafe_writer.rs
@@ -18,7 +18,7 @@ pub fn unsafe_writer<P: PinnedVec<usize>>(pinned_vec: P, max_allowed_test_len: u
     assert_eq!(vec.len(), len1);
 
     for i in len1..max_allowed_test_len {
-        if let Some(ptr) = unsafe { vec.get_ptr_mut(i) } {
+        if let Some(ptr) = vec.get_ptr_mut(i) {
             unsafe { *ptr = i };
 
             unsafe { vec.set_len(i + 1) };
@@ -32,7 +32,7 @@ pub fn unsafe_writer<P: PinnedVec<usize>>(pinned_vec: P, max_allowed_test_len: u
     }
 
     for i in vec.capacity()..(vec.capacity() + 100) {
-        assert!(unsafe { vec.get_ptr_mut(i) }.is_none());
+        assert!(vec.get_ptr_mut(i).is_none());
     }
 
     vec

--- a/src/utils/slice.rs
+++ b/src/utils/slice.rs
@@ -10,18 +10,35 @@
 /// to find its position in the vector.
 ///
 /// Out of bounds checks are in place.
+#[inline(always)]
 pub fn index_of<T>(slice: &[T], element: &T) -> Option<usize> {
-    let ptr_element = element as *const T as usize;
+    index_of_ptr(slice, element as *const T)
+}
+
+/// Returns the index of the `element` with the given reference inside the `slice`.
+/// This method has *O(1)* time complexity.
+///
+/// # Safety
+///
+/// The underlying memory of the slice `&[T]` stays pinned as long as
+/// the reference is in scope; i.e., is not carried to different memory locations.
+///
+/// Therefore, it is possible and safe to compare an element's reference
+/// to find its position in the vector.
+///
+/// Out of bounds checks are in place.
+pub fn index_of_ptr<T>(slice: &[T], element_ptr: *const T) -> Option<usize> {
+    let element_ptr = element_ptr as usize;
     let ptr = slice.as_ptr();
     let ptr_beg = ptr as usize;
-    if ptr_element < ptr_beg {
+    if element_ptr < ptr_beg {
         None
     } else {
         let ptr_end = (unsafe { ptr.add(slice.len() - 1) }) as usize;
-        if ptr_element > ptr_end {
+        if element_ptr > ptr_end {
             None
         } else {
-            let diff = ptr_element - ptr_beg;
+            let diff = element_ptr - ptr_beg;
             let count = diff / core::mem::size_of::<T>();
             Some(count)
         }
@@ -41,17 +58,31 @@ pub fn index_of<T>(slice: &[T], element: &T) -> Option<usize> {
 ///
 /// Out of bounds checks are in place.
 pub fn contains_reference<T>(slice: &[T], element: &T) -> bool {
+    contains_ptr(slice, element as *const T)
+}
+
+/// Returns whether or not element with the given pointer belongs to the given `slice`.
+/// This method has *O(1)* time complexity.
+///
+/// # Safety
+///
+/// The underlying memory of the slice `&[T]` stays pinned as long as
+/// the reference is in scope; i.e., is not carried to different memory locations.
+///
+/// Therefore, it is possible and safe to compare an element's reference
+/// to find its position in the vector.
+///
+/// Out of bounds checks are in place.
+pub fn contains_ptr<T>(slice: &[T], element_ptr: *const T) -> bool {
     if slice.is_empty() {
         false
     } else {
-        let ptr_element = element as *const T as usize;
-        let ptr = slice.as_ptr();
-        let ptr_beg = ptr as usize;
-        if ptr_element < ptr_beg {
+        let ptr_beg = slice.as_ptr();
+        if element_ptr < ptr_beg {
             false
         } else {
-            let ptr_end = (unsafe { ptr.add(slice.len() - 1) }) as usize;
-            ptr_element <= ptr_end
+            let ptr_end = unsafe { ptr_beg.add(slice.len() - 1) };
+            element_ptr <= ptr_end
         }
     }
 }


### PR DESCRIPTION
The following methods are required by pinned vectors:
* index_of_ptr
* push_get_ptr
* iter_ptr
* iter_ptr_rev
* contains_ptr
* get_ptr