### PR TITLE
iter-over-range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "3.9.0"
+version = "3.10.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/src/concurrent_pinned_vec.rs
+++ b/src/concurrent_pinned_vec.rs
@@ -53,6 +53,20 @@ pub trait ConcurrentPinnedVec<T> {
     where
         T: 'a;
 
+    /// Returns an iterator over positions `range` of the vector.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe since the concurrent pinned vector might contain gaps.
+    ///
+    /// This method can safely be called if entries in all positions `range` are written.
+    unsafe fn iter_over_range<'a, R: RangeBounds<usize>>(
+        &'a self,
+        range: R,
+    ) -> impl Iterator<Item = &'a T> + 'a
+    where
+        T: 'a;
+
     /// Returns a reference to the element at the `index`-th position.
     ///
     /// # Safety

--- a/src/utils/slice.rs
+++ b/src/utils/slice.rs
@@ -1,3 +1,5 @@
+use core::ops::RangeBounds;
+
 /// Returns the index of the `element` with the given reference inside the `slice`.
 /// This method has *O(1)* time complexity.
 ///
@@ -85,6 +87,43 @@ pub fn contains_ptr<T>(slice: &[T], element_ptr: *const T) -> bool {
             element_ptr <= ptr_end
         }
     }
+}
+
+/// Returns the inclusive being and exclusive end of the given `range`.
+/// The range is bounded by the `vec_len` if it is known and provided.
+///
+/// # Panics
+///
+/// Panics if end bound is Unbounded while vec_len is None.
+pub fn vec_range_limits<R: RangeBounds<usize>>(range: &R, vec_len: Option<usize>) -> [usize; 2] {
+    use core::ops::Bound::*;
+
+    let mut begin = match range.start_bound() {
+        Included(&a) => a,
+        Excluded(a) => a + 1,
+        Unbounded => 0,
+    };
+
+    let mut end = match range.end_bound() {
+        Excluded(&b) => b,
+        Included(b) => b + 1,
+        Unbounded => vec_len.expect("Unbounded range without a vec_len"),
+    };
+
+    if end < begin {
+        end = begin;
+    }
+
+    if let Some(len) = vec_len {
+        if begin > len {
+            begin = len;
+        }
+        if end > len {
+            end = len;
+        }
+    }
+
+    [begin, end]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`iter_over_range` method is provided.

At one hand, `vec.iter_over_range(a..b)` is equivalent to `vec.iter().skip(a).take(b - a)`. However, the latter requires `a` unnecessary `next` calls. Since all pinned vectors provide random access to elements, the objective of `iter_over_range` is to directly jump to `a` and create an iterator from this point on, and hence, avoiding the unnecessary iterations at the beginning.

Also
* vec_range_limits helper method is also provided.