### PR TITLE
pinned vectors require Collection and CollectionMut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ keywords = ["vec", "array", "vector", "pinned", "memory"]
 categories = ["data-structures", "rust-patterns", "no-std"]
 
 [dependencies]
+orx-iterable = { version = "1.1.1", default-features = false }
 orx-pseudo-default = { version = "1.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "3.11.0"
+version = "3.12.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,5 +28,6 @@ pub use capacity::CapacityState;
 pub use concurrent_pinned_vec::ConcurrentPinnedVec;
 pub use errors::PinnedVecGrowthError;
 pub use into_concurrent_pinned_vec::IntoConcurrentPinnedVec;
+pub use orx_iterable::{Collection, CollectionMut, Iterable};
 pub use pinned_vec::PinnedVec;
 pub use pinned_vec_tests::test_pinned_vec;

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -3,6 +3,7 @@ use core::{
     cmp::Ordering,
     ops::{Index, IndexMut, RangeBounds},
 };
+use orx_iterable::{Collection, CollectionMut};
 use orx_pseudo_default::PseudoDefault;
 
 /// Trait for vector representations differing from `std::vec::Vec` by the following:
@@ -31,20 +32,13 @@ use orx_pseudo_default::PseudoDefault;
 /// | `remove(a)` | does not change the memory locations of the first `a` elements, where `a < n`; elements to the right of the removed element might be changed, commonly shifted to left |
 /// | `truncate(a)` | does not change the memory locations of the first `a` elements, where `a < n` |
 pub trait PinnedVec<T>:
-    IntoIterator<Item = T> + PseudoDefault + Index<usize, Output = T> + IndexMut<usize, Output = T>
+    IntoIterator<Item = T>
+    + Collection<Item = T>
+    + CollectionMut<Item = T>
+    + PseudoDefault
+    + Index<usize, Output = T>
+    + IndexMut<usize, Output = T>
 {
-    /// Iterator yielding references to the elements of the vector.
-    type Iter<'a>: Iterator<Item = &'a T>
-    where
-        T: 'a,
-        Self: 'a;
-
-    /// Iterator yielding mutable references to the elements of the vector.
-    type IterMut<'a>: Iterator<Item = &'a mut T>
-    where
-        T: 'a,
-        Self: 'a;
-
     /// Iterator yielding references to the elements of the vector.
     type IterRev<'a>: Iterator<Item = &'a T>
     where
@@ -266,10 +260,6 @@ pub trait PinnedVec<T>:
     /// effect.
     fn truncate(&mut self, len: usize);
 
-    /// Returns an iterator to elements of the vector.
-    fn iter(&self) -> Self::Iter<'_>;
-    /// Returns an iterator of mutable references to elements of the vector.
-    fn iter_mut(&mut self) -> Self::IterMut<'_>;
     /// Returns a reversed back-to-front iterator to elements of the vector.
     fn iter_rev(&self) -> Self::IterRev<'_>;
     /// Returns a reversed back-to-front iterator mutable references to elements of the vector.

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -39,6 +39,7 @@ mod tests {
         iter::Rev,
         ops::{Index, IndexMut, RangeBounds},
     };
+    use orx_iterable::Collection;
     use orx_pseudo_default::PseudoDefault;
 
     #[derive(Debug)]
@@ -78,17 +79,27 @@ mod tests {
         }
     }
 
+    impl<'a, T> IntoIterator for &'a JustVec<T> {
+        type Item = &'a T;
+
+        type IntoIter = core::slice::Iter<'a, T>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.0.iter()
+        }
+    }
+
+    impl<'a, T> IntoIterator for &'a mut JustVec<T> {
+        type Item = &'a mut T;
+
+        type IntoIter = core::slice::IterMut<'a, T>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.0.iter_mut()
+        }
+    }
+
     impl<T> PinnedVec<T> for JustVec<T> {
-        type Iter<'a>
-            = core::slice::Iter<'a, T>
-        where
-            T: 'a,
-            Self: 'a;
-        type IterMut<'a>
-            = core::slice::IterMut<'a, T>
-        where
-            T: 'a,
-            Self: 'a;
         type IterRev<'a>
             = Rev<core::slice::Iter<'a, T>>
         where
@@ -228,14 +239,6 @@ mod tests {
 
         fn truncate(&mut self, len: usize) {
             self.0.truncate(len)
-        }
-
-        fn iter(&self) -> Self::Iter<'_> {
-            self.0.iter()
-        }
-
-        fn iter_mut(&mut self) -> Self::IterMut<'_> {
-            self.0.iter_mut()
         }
 
         fn iter_rev(&self) -> Self::IterRev<'_> {

--- a/src/pinned_vec_tests/testvec.rs
+++ b/src/pinned_vec_tests/testvec.rs
@@ -6,6 +6,7 @@ use core::{
     iter::Rev,
     ops::{Index, IndexMut, RangeBounds},
 };
+use orx_iterable::Collection;
 use orx_pseudo_default::PseudoDefault;
 
 pub struct TestVec<T>(Vec<T>);
@@ -49,17 +50,27 @@ impl<T> IntoIterator for TestVec<T> {
     }
 }
 
+impl<'a, T> IntoIterator for &'a TestVec<T> {
+    type Item = &'a T;
+
+    type IntoIter = core::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut TestVec<T> {
+    type Item = &'a mut T;
+
+    type IntoIter = core::slice::IterMut<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}
+
 impl<T> PinnedVec<T> for TestVec<T> {
-    type Iter<'a>
-        = core::slice::Iter<'a, T>
-    where
-        T: 'a,
-        Self: 'a;
-    type IterMut<'a>
-        = core::slice::IterMut<'a, T>
-    where
-        T: 'a,
-        Self: 'a;
     type IterRev<'a>
         = Rev<core::slice::Iter<'a, T>>
     where
@@ -199,14 +210,6 @@ impl<T> PinnedVec<T> for TestVec<T> {
 
     fn truncate(&mut self, len: usize) {
         self.0.truncate(len)
-    }
-
-    fn iter(&self) -> Self::Iter<'_> {
-        self.0.iter()
-    }
-
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        self.0.iter_mut()
     }
 
     fn iter_rev(&self) -> Self::IterRev<'_> {

--- a/tests/std_vec_tests.rs
+++ b/tests/std_vec_tests.rs
@@ -1,3 +1,4 @@
+use orx_iterable::Collection;
 use orx_pinned_vec::*;
 use orx_pseudo_default::PseudoDefault;
 use std::{
@@ -43,17 +44,27 @@ impl<T> IntoIterator for StdVec<T> {
     }
 }
 
+impl<'a, T> IntoIterator for &'a StdVec<T> {
+    type Item = &'a T;
+
+    type IntoIter = core::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut StdVec<T> {
+    type Item = &'a mut T;
+
+    type IntoIter = core::slice::IterMut<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}
+
 impl<T> PinnedVec<T> for StdVec<T> {
-    type Iter<'a>
-        = core::slice::Iter<'a, T>
-    where
-        T: 'a,
-        Self: 'a;
-    type IterMut<'a>
-        = core::slice::IterMut<'a, T>
-    where
-        T: 'a,
-        Self: 'a;
     type IterRev<'a>
         = Rev<core::slice::Iter<'a, T>>
     where
@@ -190,14 +201,6 @@ impl<T> PinnedVec<T> for StdVec<T> {
 
     fn truncate(&mut self, len: usize) {
         self.0.truncate(len)
-    }
-
-    fn iter(&self) -> Self::Iter<'_> {
-        self.0.iter()
-    }
-
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        self.0.iter_mut()
     }
 
     fn iter_rev(&self) -> Self::IterRev<'_> {


### PR DESCRIPTION
Rather than requiring `iter` and `iter_mut` methods, pinned vectors now follow the pattern defined in orx-iterable crate; i.e.,:

* `P: PinnedVec<T>` implements `IntoIterator<Item = T>`
* `&P` implements `IntoIterator<Item = &T>`
* `&mut P` implements `IntoIterator<Item = &mut T>`

With these implementations, every pinned vector implicitly implements `Collection` and `CollectionMut` providing `iter` and `iter_mut` methods.
