### PR TITLE
iter_over is required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: ["stable"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install toolchain
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}
+
+    - name: Install 32bit target
+      run: rustup target add i686-unknown-linux-musl
+    - name: Install wasm target
+      run: rustup target add wasm32v1-none
+    - name: Install miri
+      run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri
+    - name: Install no-std-check
+      run: cargo install cargo-no-std-check
+      
+    - name: Build
+      run: cargo build --verbose
+    - name: Build-32bit
+      run: cargo build --verbose --target i686-unknown-linux-musl
+    - name: Build-wasm
+      run: cargo build --verbose --target wasm32v1-none
+
+    - name: Test
+      run: cargo test --verbose
+    - name: Test-32bit
+      run: cargo test --verbose --target i686-unknown-linux-musl
+    - name: Check-wasm
+      run: cargo check --verbose --target wasm32v1-none
+
+    - name: Clippy
+      run: cargo clippy -- -D warnings --verbose
+
+    - name: Miri
+      run: cargo +nightly miri test --verbose
+
+    - name: NoStd
+      run: cargo +nightly no-std-check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "3.15.0"
+version = "4.0.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-pinned-vec"
-version = "4.0.0"
+version = "3.16.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."
@@ -10,5 +10,5 @@ keywords = ["vec", "array", "vector", "pinned", "memory"]
 categories = ["data-structures", "rust-patterns", "no-std"]
 
 [dependencies]
-orx-iterable = { version = "1.2.0", default-features = false }
-orx-pseudo-default = { version = "2.0.0", default-features = false }
+orx-iterable = { version = "1.3.0", default-features = false }
+orx-pseudo-default = { version = "2.1.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "orx-pinned-vec"
 version = "3.15.0"
-edition = "2021"
+edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed."
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 `PinnedVec` trait defines the interface for vectors which guarantee that elements added to the vector are pinned to their memory locations unless explicitly changed.
 
+> This crate is **no-std** by default.
+
 ## Pinned Elements Guarantees
 
 A `PinnedVec` guarantees that positions of its elements **do not change implicitly**.

--- a/src/concurrent_pinned_vec.rs
+++ b/src/concurrent_pinned_vec.rs
@@ -12,6 +12,18 @@ pub trait ConcurrentPinnedVec<T> {
     /// Type of the wrapped pinned vector.
     type P: PinnedVec<T>;
 
+    /// Iterator yielding slices corresponding to a range of indices, returned by the `slice` method.
+    type SliceIter<'a>: IntoIterator<Item = &'a [T]> + Default
+    where
+        T: 'a,
+        Self: 'a;
+
+    /// Iterator yielding mutable slices corresponding to a range of indices, returned by the `slice_mut` and `slice_mut_unchecked` methods.
+    type SliceMutIter<'a>: IntoIterator<Item = &'a mut [T]> + Default
+    where
+        T: 'a,
+        Self: 'a;
+
     /// Converts back to the underlying pinned vector with the given length.
     ///
     /// # Safety
@@ -90,13 +102,10 @@ pub trait ConcurrentPinnedVec<T> {
     ///
     /// This method is used to write to the vector.
     /// Therefore, the positions will initially be uninitialized; hence, reading from the slices might result in UB.
-    unsafe fn slices_mut<R: RangeBounds<usize>>(
-        &self,
-        range: R,
-    ) -> <Self::P as PinnedVec<T>>::SliceMutIter<'_>;
+    unsafe fn slices_mut<R: RangeBounds<usize>>(&self, range: R) -> Self::SliceMutIter<'_>;
 
     /// Returns an iterator of slices to the elements extending over positions `range` of the vector.
-    fn slices<R: RangeBounds<usize>>(&self, range: R) -> <Self::P as PinnedVec<T>>::SliceIter<'_>;
+    fn slices<R: RangeBounds<usize>>(&self, range: R) -> Self::SliceIter<'_>;
 
     // capacity
 

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -277,6 +277,20 @@ pub trait PinnedVec<T>:
     /// * returns an iterator yielding ordered slices that forms the required range when chained.
     fn slices_mut<R: RangeBounds<usize>>(&mut self, range: R) -> Self::SliceMutIter<'_>;
 
+    fn iter_over<'a>(
+        &'a self,
+        range: impl RangeBounds<usize>,
+    ) -> impl ExactSizeIterator<Item = &'a T>
+    where
+        T: 'a;
+
+    fn iter_mut_over<'a>(
+        &'a mut self,
+        range: impl RangeBounds<usize>,
+    ) -> impl ExactSizeIterator<Item = &'a mut T>
+    where
+        T: 'a;
+
     /// Returns a pointer to the `index`-th element of the vector.
     ///
     /// Returns `None` if `index`-th position does not belong to the vector; i.e., if `index` is out of `capacity`.

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -473,11 +473,14 @@ pub trait PinnedVec<T>:
     where
         F: FnMut(&T) -> K,
         K: Ord;
+
+    /// Returns the maximum possible capacity that the vector can grow to.
+    fn capacity_bound(&self) -> usize;
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{pinned_vec_tests::testvec::TestVec, PinnedVec};
+    use crate::{PinnedVec, pinned_vec_tests::testvec::TestVec};
 
     #[test]
     fn is_empty() {

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -277,6 +277,14 @@ pub trait PinnedVec<T>:
     /// * returns an iterator yielding ordered slices that forms the required range when chained.
     fn slices_mut<R: RangeBounds<usize>>(&mut self, range: R) -> Self::SliceMutIter<'_>;
 
+    /// Creates an exact size iterator for elements over the given `range`.
+    ///
+    /// This method can be considered as a generalization of creating a slice of a vector
+    /// such that it does not necessarily return a contagious slice of elements. It might
+    /// as well return a sequence of multiple slices, as long as the elements are positioned
+    /// at the given `range` of indices.
+    ///
+    /// [`Vec::slice`]: std::vec::Vec::slice
     fn iter_over<'a>(
         &'a self,
         range: impl RangeBounds<usize>,
@@ -284,6 +292,14 @@ pub trait PinnedVec<T>:
     where
         T: 'a;
 
+    /// Creates a mutable exact size iterator for elements over the given `range`.
+    ///
+    /// This method can be considered as a generalization of creating a mutable slice of a vector
+    /// such that it does not necessarily return a contagious slice of elements. It might
+    /// as well return a sequence of multiple slices, as long as the elements are positioned
+    /// at the given `range` of indices.
+    ///
+    /// [`Vec::slice`]: std::vec::Vec::slice
     fn iter_mut_over<'a>(
         &'a mut self,
         range: impl RangeBounds<usize>,

--- a/src/pinned_vec_tests/extend.rs
+++ b/src/pinned_vec_tests/extend.rs
@@ -69,8 +69,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(miri))]
     fn test_extend_medium() {
-        let capacity = 512;
+        let capacity = 256;
         let pinned_vec = TestVec::new(capacity);
         extend(pinned_vec, capacity);
     }

--- a/src/pinned_vec_tests/insert.rs
+++ b/src/pinned_vec_tests/insert.rs
@@ -55,6 +55,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(miri))]
     fn test_insert_medium() {
         let capacity = 256;
         let pinned_vec = TestVec::new(capacity);

--- a/src/pinned_vec_tests/pop.rs
+++ b/src/pinned_vec_tests/pop.rs
@@ -54,6 +54,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(miri))]
     fn test_pop_medium() {
         let capacity = 256;
         let pinned_vec = TestVec::new(capacity);

--- a/src/pinned_vec_tests/push.rs
+++ b/src/pinned_vec_tests/push.rs
@@ -49,8 +49,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(miri))]
     fn test_push_medium() {
-        let capacity = 512;
+        let capacity = 256;
         let pinned_vec = TestVec::new(capacity);
         push(pinned_vec, capacity);
     }

--- a/src/pinned_vec_tests/remove.rs
+++ b/src/pinned_vec_tests/remove.rs
@@ -56,6 +56,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(miri))]
     fn test_remove_medium() {
         let capacity = 256;
         let pinned_vec = TestVec::new(capacity);

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -39,7 +39,7 @@ mod tests {
         iter::Rev,
         ops::{Index, IndexMut, RangeBounds},
     };
-    use orx_iterable::Collection;
+    use orx_iterable::{Collection, Iterable};
     use orx_pseudo_default::PseudoDefault;
 
     #[derive(Debug)]
@@ -275,6 +275,38 @@ mod tests {
                     _ => Some(&mut self.0[a..b]),
                 },
             }
+        }
+
+        fn iter_over<'a>(
+            &'a self,
+            range: impl RangeBounds<usize>,
+        ) -> impl ExactSizeIterator<Item = &'a T>
+        where
+            T: 'a,
+        {
+            use core::cmp::{max, min};
+
+            let len = PinnedVec::len(self);
+            let a = min(len, range_start(&range));
+            let b = max(a, min(len, range_end(&range, len)));
+
+            self.0[a..b].iter()
+        }
+
+        fn iter_mut_over<'a>(
+            &'a mut self,
+            range: impl RangeBounds<usize>,
+        ) -> impl ExactSizeIterator<Item = &'a mut T>
+        where
+            T: 'a,
+        {
+            use core::cmp::{max, min};
+
+            let len = PinnedVec::len(self);
+            let a = min(len, range_start(&range));
+            let b = max(a, min(len, range_end(&range, len)));
+
+            self.0[a..b].iter_mut()
         }
 
         fn get_ptr(&self, index: usize) -> Option<*const T> {

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -364,7 +364,11 @@ mod tests {
 
     #[test]
     fn within_capacity_vec_passes() {
+        #[cfg(not(miri))]
         let capacity = 129;
+        #[cfg(miri)]
+        let capacity = 29;
+
         let vec = JustVec(Vec::with_capacity(capacity));
         test_pinned_vec(vec, capacity);
     }

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -30,8 +30,9 @@ pub fn test_pinned_vec<P: PinnedVec<usize>>(pinned_vec: P, test_vec_len: usize) 
 mod tests {
     use super::*;
     use crate::{
+        CapacityState,
         pinned_vec_tests::helpers::range::{range_end, range_start},
-        utils, CapacityState,
+        utils,
     };
     use alloc::vec::Vec;
     use core::{
@@ -39,7 +40,7 @@ mod tests {
         iter::Rev,
         ops::{Index, IndexMut, RangeBounds},
     };
-    use orx_iterable::{Collection, Iterable};
+    use orx_iterable::Collection;
     use orx_pseudo_default::PseudoDefault;
 
     #[derive(Debug)]
@@ -188,11 +189,11 @@ mod tests {
         }
 
         unsafe fn get_unchecked(&self, index: usize) -> &T {
-            self.0.get_unchecked(index)
+            unsafe { self.0.get_unchecked(index) }
         }
 
         unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
-            self.0.get_unchecked_mut(index)
+            unsafe { self.0.get_unchecked_mut(index) }
         }
 
         fn first(&self) -> Option<&T> {
@@ -318,7 +319,7 @@ mod tests {
         }
 
         unsafe fn set_len(&mut self, new_len: usize) {
-            self.0.set_len(new_len)
+            unsafe { self.0.set_len(new_len) }
         }
 
         fn binary_search_by<F>(&self, f: F) -> Result<usize, usize>

--- a/src/pinned_vec_tests/test_all.rs
+++ b/src/pinned_vec_tests/test_all.rs
@@ -350,6 +350,10 @@ mod tests {
         {
             self.0.sort_by_key(f)
         }
+
+        fn capacity_bound(&self) -> usize {
+            usize::MAX
+        }
     }
 
     #[test]

--- a/src/pinned_vec_tests/testvec.rs
+++ b/src/pinned_vec_tests/testvec.rs
@@ -159,11 +159,11 @@ impl<T> PinnedVec<T> for TestVec<T> {
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> &T {
-        self.0.get_unchecked(index)
+        unsafe { self.0.get_unchecked(index) }
     }
 
     unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
-        self.0.get_unchecked_mut(index)
+        unsafe { self.0.get_unchecked_mut(index) }
     }
 
     fn first(&self) -> Option<&T> {
@@ -289,7 +289,7 @@ impl<T> PinnedVec<T> for TestVec<T> {
     }
 
     unsafe fn set_len(&mut self, new_len: usize) {
-        self.0.set_len(new_len)
+        unsafe { self.0.set_len(new_len) }
     }
 
     fn binary_search_by<F>(&self, f: F) -> Result<usize, usize>

--- a/src/pinned_vec_tests/testvec.rs
+++ b/src/pinned_vec_tests/testvec.rs
@@ -248,6 +248,38 @@ impl<T> PinnedVec<T> for TestVec<T> {
         }
     }
 
+    fn iter_over<'a>(
+        &'a self,
+        range: impl RangeBounds<usize>,
+    ) -> impl ExactSizeIterator<Item = &'a T>
+    where
+        T: 'a,
+    {
+        use core::cmp::{max, min};
+
+        let len = PinnedVec::len(self);
+        let a = min(len, range_start(&range));
+        let b = max(a, min(len, range_end(&range, len)));
+
+        self.0[a..b].iter()
+    }
+
+    fn iter_mut_over<'a>(
+        &'a mut self,
+        range: impl RangeBounds<usize>,
+    ) -> impl ExactSizeIterator<Item = &'a mut T>
+    where
+        T: 'a,
+    {
+        use core::cmp::{max, min};
+
+        let len = PinnedVec::len(self);
+        let a = min(len, range_start(&range));
+        let b = max(a, min(len, range_end(&range, len)));
+
+        self.0[a..b].iter_mut()
+    }
+
     fn get_ptr(&self, index: usize) -> Option<*const T> {
         (index < self.0.capacity()).then(|| unsafe { self.0.as_ptr().add(index) })
     }

--- a/src/pinned_vec_tests/testvec.rs
+++ b/src/pinned_vec_tests/testvec.rs
@@ -320,4 +320,8 @@ impl<T> PinnedVec<T> for TestVec<T> {
     {
         self.0.sort_by_key(f)
     }
+
+    fn capacity_bound(&self) -> usize {
+        usize::MAX
+    }
 }

--- a/src/pinned_vec_tests/truncate.rs
+++ b/src/pinned_vec_tests/truncate.rs
@@ -52,6 +52,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(miri))]
     fn test_truncate_medium() {
         let capacity = 512;
         let pinned_vec = TestVec::new(capacity);

--- a/tests/std_vec_tests.rs
+++ b/tests/std_vec_tests.rs
@@ -334,79 +334,84 @@ fn range_end<R: RangeBounds<usize>>(range: &R, vec_len: usize) -> usize {
 
 // PINNED ELEMENT TESTS
 
+#[cfg(not(miri))]
+const N: usize = 64 * 1024;
+#[cfg(miri)]
+const N: usize = 256;
+
 #[test]
 fn std_vec_extend_with_capacity() {
-    pinned_vec_tests::extend(StdVec(Vec::with_capacity(64 * 1024)), 64 * 1024);
+    pinned_vec_tests::extend(StdVec(Vec::with_capacity(N)), N);
 }
 
 #[test]
 #[should_panic]
 fn std_vec_extend() {
-    pinned_vec_tests::extend(StdVec(Vec::new()), 64 * 1024);
+    pinned_vec_tests::extend(StdVec(Vec::new()), N);
 }
 
 #[test]
 fn std_vec_insert_with_capacity() {
-    pinned_vec_tests::insert(StdVec(Vec::with_capacity(64 * 1024)), 64 * 1024);
+    pinned_vec_tests::insert(StdVec(Vec::with_capacity(N)), N);
 }
 
 #[test]
 #[should_panic]
 fn std_vec_insert() {
-    pinned_vec_tests::insert(StdVec(Vec::new()), 64 * 1024);
+    pinned_vec_tests::insert(StdVec(Vec::new()), N);
 }
 
 #[test]
 fn std_vec_pop_with_capacity() {
-    pinned_vec_tests::pop(StdVec(Vec::with_capacity(64 * 1024)), 64 * 1024);
+    pinned_vec_tests::pop(StdVec(Vec::with_capacity(N)), N);
 }
 
 #[test]
 #[should_panic]
 fn std_vec_pop() {
-    pinned_vec_tests::pop(StdVec(Vec::new()), 64 * 1024);
+    pinned_vec_tests::pop(StdVec(Vec::new()), N);
 }
 
 #[test]
 fn std_vec_push_with_capacity() {
-    pinned_vec_tests::push(StdVec(Vec::with_capacity(64 * 1024)), 64 * 1024);
+    pinned_vec_tests::push(StdVec(Vec::with_capacity(N)), N);
 }
 
 #[test]
 #[should_panic]
 fn std_vec_push() {
-    pinned_vec_tests::push(StdVec(Vec::new()), 64 * 1024);
+    pinned_vec_tests::push(StdVec(Vec::new()), N);
 }
 
 #[test]
 fn std_vec_remove_with_capacity() {
-    pinned_vec_tests::remove(StdVec(Vec::with_capacity(64 * 1024)), 64 * 1024);
+    pinned_vec_tests::remove(StdVec(Vec::with_capacity(N)), N);
 }
 
 #[test]
 #[should_panic]
 fn std_vec_remove() {
-    pinned_vec_tests::remove(StdVec(Vec::new()), 64 * 1024);
+    pinned_vec_tests::remove(StdVec(Vec::new()), N);
 }
 
 #[test]
 fn std_vec_truncate_with_capacity() {
-    pinned_vec_tests::truncate(StdVec(Vec::with_capacity(64 * 1024)), 64 * 1024);
+    pinned_vec_tests::truncate(StdVec(Vec::with_capacity(N)), N);
 }
 
 #[test]
 #[should_panic]
 fn std_vec_truncate() {
-    pinned_vec_tests::truncate(StdVec(Vec::new()), 64 * 1024);
+    pinned_vec_tests::truncate(StdVec(Vec::new()), N);
 }
 
 #[test]
 fn std_vec_all_with_capacity() {
-    pinned_vec_tests::test_pinned_vec(StdVec(Vec::with_capacity(64 * 1024)), 64 * 1024);
+    pinned_vec_tests::test_pinned_vec(StdVec(Vec::with_capacity(N)), N);
 }
 
 #[test]
 #[should_panic]
 fn std_vec_all() {
-    pinned_vec_tests::test_pinned_vec(StdVec(Vec::new()), 64 * 1024);
+    pinned_vec_tests::test_pinned_vec(StdVec(Vec::new()), N);
 }

--- a/tests/std_vec_tests.rs
+++ b/tests/std_vec_tests.rs
@@ -311,6 +311,10 @@ impl<T> PinnedVec<T> for StdVec<T> {
     {
         self.0.sort_by_key(f)
     }
+
+    fn capacity_bound(&self) -> usize {
+        usize::MAX
+    }
 }
 
 fn range_start<R: RangeBounds<usize>>(range: &R) -> usize {

--- a/tests/std_vec_tests.rs
+++ b/tests/std_vec_tests.rs
@@ -152,11 +152,11 @@ impl<T> PinnedVec<T> for StdVec<T> {
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> &T {
-        self.0.get_unchecked(index)
+        unsafe { self.0.get_unchecked(index) }
     }
 
     unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
-        self.0.get_unchecked_mut(index)
+        unsafe { self.0.get_unchecked_mut(index) }
     }
 
     fn first(&self) -> Option<&T> {
@@ -280,7 +280,7 @@ impl<T> PinnedVec<T> for StdVec<T> {
     }
 
     unsafe fn set_len(&mut self, new_len: usize) {
-        self.0.set_len(new_len)
+        unsafe { self.0.set_len(new_len) }
     }
 
     fn binary_search_by<F>(&self, f: F) -> Result<usize, usize>

--- a/tests/std_vec_tests.rs
+++ b/tests/std_vec_tests.rs
@@ -239,6 +239,38 @@ impl<T> PinnedVec<T> for StdVec<T> {
         }
     }
 
+    fn iter_over<'a>(
+        &'a self,
+        range: impl RangeBounds<usize>,
+    ) -> impl ExactSizeIterator<Item = &'a T>
+    where
+        T: 'a,
+    {
+        use core::cmp::{max, min};
+
+        let len = PinnedVec::len(self);
+        let a = min(len, range_start(&range));
+        let b = max(a, min(len, range_end(&range, len)));
+
+        self.0[a..b].iter()
+    }
+
+    fn iter_mut_over<'a>(
+        &'a mut self,
+        range: impl RangeBounds<usize>,
+    ) -> impl ExactSizeIterator<Item = &'a mut T>
+    where
+        T: 'a,
+    {
+        use core::cmp::{max, min};
+
+        let len = PinnedVec::len(self);
+        let a = min(len, range_start(&range));
+        let b = max(a, min(len, range_end(&range, len)));
+
+        self.0[a..b].iter_mut()
+    }
+
     fn get_ptr(&self, index: usize) -> Option<*const T> {
         (index < self.0.capacity()).then(|| unsafe { self.0.as_ptr().add(index) })
     }

--- a/tests/std_vec_tests.rs
+++ b/tests/std_vec_tests.rs
@@ -337,7 +337,7 @@ fn range_end<R: RangeBounds<usize>>(range: &R, vec_len: usize) -> usize {
 #[cfg(not(miri))]
 const N: usize = 64 * 1024;
 #[cfg(miri)]
-const N: usize = 256;
+const N: usize = 56;
 
 #[test]
 fn std_vec_extend_with_capacity() {


### PR DESCRIPTION
Migration to 2024edition.

Pinned vectors require to be `Collection` and `CollectionMut`.

`iter_over` and `iter_over_mut` methods are defined as a generalization of slicing of vectors.

CI action is added.

Documentation is updated for no-std.

